### PR TITLE
Improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Uptime Monitor is a self-hosted web monitoring tool, built with laravel.
 - Monitor your web uptime per minutes (or any time interval)
 - Record response time on each web
 - Show uptime badges in 3 colors: green for up, yellow for warning, red for down, based on response time
-- Send telegram notification when you site down for 5 minutes (based on check periode)
+- Send telegram notification when you site down for 5 minutes (based on check period) or when your site response time above "down" threshold
 
 ## Why I need this?
 
@@ -78,6 +78,9 @@ In order to get notified in Telegram when the customer sites are down, we need t
     - Select one of the customer site and click Edit link
     - Set the Notify User Interval field, between 0 to 60.
     - Set the Notify User Interval field to 0 if you don't want to get notified.
+
+### Tips
+Set QUEUE_CONNECTION variable on your .env to database and use supervisor to optime monitoring check, using this approach you can achieve near to async check proccess
 
 ## Screenshot
 

--- a/app/Console/Commands/MonitorURLs.php
+++ b/app/Console/Commands/MonitorURLs.php
@@ -14,14 +14,16 @@ class MonitorURLs extends Command
 
     public function handle()
     {
-        $customerSites = CustomerSite::where('is_active', 1)->get(); // Add your desired URLs here
+        $customerSites = CustomerSite::where('is_active', 1)
+            ->orderByRaw("FIELD (priority_code, 'high', 'normal', 'low')")
+            ->get(); // Add your desired URLs here
 
         foreach ($customerSites as $customerSite) {
             if (!$customerSite->needToCheck()) {
                 continue;
             }
 
-            RunCheck::dispatch($customerSite);
+            dispatch(new RunCheck($customerSite));
         }
 
         $this->info('URLs monitored successfully.');

--- a/app/Console/Commands/NotifyUser.php
+++ b/app/Console/Commands/NotifyUser.php
@@ -32,7 +32,7 @@ class NotifyUser extends Command
                 ->where('customer_site_id', $customerSite->id)
                 ->orderBy('created_at', 'desc')
                 ->take(5)
-                ->get(['response_time', 'status_code', 'created_at']);
+                ->get(['response_time', 'status_code', 'visibility', 'created_at']);
             $responseTimeAverage = $responseTimes->avg('response_time');
             if ($responseTimeAverage >= ($customerSite->down_threshold * 0.9)) {
                 // DETERMINE IS WEBISTE SLOW OR DOWN

--- a/app/Console/Commands/NotifyUser.php
+++ b/app/Console/Commands/NotifyUser.php
@@ -35,7 +35,7 @@ class NotifyUser extends Command
                 ->get(['response_time', 'status_code', 'created_at']);
             $responseTimeAverage = $responseTimes->avg('response_time');
             if ($responseTimeAverage >= ($customerSite->down_threshold * 0.9)) {
-                notifyTelegramUser($customerSite, $responseTimes);
+                notifyTelegramUser($customerSite, $responseTimes, "Slow");
                 $customerSite->last_notify_user_at = Carbon::now();
                 $customerSite->save();
             }

--- a/app/Console/Commands/NotifyUser.php
+++ b/app/Console/Commands/NotifyUser.php
@@ -32,7 +32,7 @@ class NotifyUser extends Command
                 ->where('customer_site_id', $customerSite->id)
                 ->orderBy('created_at', 'desc')
                 ->take(5)
-                ->get(['response_time', 'status_code', 'visibility', 'created_at']);
+                ->get(['response_time', 'status_code', 'created_at']);
             $responseTimeAverage = $responseTimes->avg('response_time');
             if ($responseTimeAverage >= ($customerSite->down_threshold * 0.9)) {
                 // DETERMINE IS WEBISTE SLOW OR DOWN

--- a/app/Console/Commands/NotifyUser.php
+++ b/app/Console/Commands/NotifyUser.php
@@ -34,44 +34,13 @@ class NotifyUser extends Command
                 ->take(5)
                 ->get(['response_time', 'created_at']);
             $responseTimeAverage = $responseTimes->avg('response_time');
-            if ($responseTimes->avg('response_time') >= ($customerSite->down_threshold * 0.9)) {
-                $this->notifyUser($customerSite, $responseTimes);
+            if ($responseTimeAverage >= ($customerSite->down_threshold * 0.9)) {
+                notifyTelegramUser($customerSite, $responseTimes);
                 $customerSite->last_notify_user_at = Carbon::now();
                 $customerSite->save();
             }
         }
 
         $this->info('Done!');
-    }
-
-    private function notifyUser(CustomerSite $customerSite, Collection $responseTimes): void
-    {
-        if (is_null($customerSite->owner)) {
-            Log::channel('daily')->info('Missing customer site owner', $customerSite->toArray());
-            return;
-        }
-
-        $telegramChatId = $customerSite->owner->telegram_chat_id;
-        if (is_null($telegramChatId)) {
-            Log::channel('daily')->info('Missing telegram_chat_id form owner', $customerSite->toArray());
-            return;
-        }
-
-        $endpoint = 'https://api.telegram.org/bot'.config('services.telegram_notifier.token').'/sendMessage';
-        $text = "";
-        $text .= "Uptime: Website Down";
-        $text .= "\n\n".$customerSite->name.' ('.$customerSite->url.')';
-        $text .= "\n\nLast 5 response time:";
-        $text .= "\n";
-        foreach ($responseTimes as $responseTime) {
-            $text .= $responseTime->created_at->format('H:i:s').':   '.$responseTime->response_time.' ms';
-            $text .= "\n";
-        }
-        $text .= "\nCheck here:";
-        $text .= "\n".route('customer_sites.show', [$customerSite->id]);
-        Http::post($endpoint, [
-            'chat_id' => $telegramChatId,
-            'text' => $text,
-        ]);
     }
 }

--- a/app/Console/Commands/NotifyUser.php
+++ b/app/Console/Commands/NotifyUser.php
@@ -35,7 +35,12 @@ class NotifyUser extends Command
                 ->get(['response_time', 'status_code', 'created_at']);
             $responseTimeAverage = $responseTimes->avg('response_time');
             if ($responseTimeAverage >= ($customerSite->down_threshold * 0.9)) {
-                notifyTelegramUser($customerSite, $responseTimes, "Slow");
+                // DETERMINE IS WEBISTE SLOW OR DOWN
+                $latest_log = $responseTimes->first();
+                if ($latest_log->status_code != 200) $webStatus = "Down";
+                else $webStatus = "Slow";
+
+                notifyTelegramUser($customerSite, $responseTimes, $webStatus);
                 $customerSite->last_notify_user_at = Carbon::now();
                 $customerSite->save();
             }

--- a/app/Console/Commands/NotifyUser.php
+++ b/app/Console/Commands/NotifyUser.php
@@ -32,7 +32,7 @@ class NotifyUser extends Command
                 ->where('customer_site_id', $customerSite->id)
                 ->orderBy('created_at', 'desc')
                 ->take(5)
-                ->get(['response_time', 'created_at']);
+                ->get(['response_time', 'status_code', 'created_at']);
             $responseTimeAverage = $responseTimes->avg('response_time');
             if ($responseTimeAverage >= ($customerSite->down_threshold * 0.9)) {
                 notifyTelegramUser($customerSite, $responseTimes);

--- a/app/Http/Controllers/CustomerSiteController.php
+++ b/app/Http/Controllers/CustomerSiteController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Jobs\RunCheck;
 use App\Models\CustomerSite;
+use App\Models\CustomerSiteType;
 use App\Models\Vendor;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
@@ -37,8 +38,9 @@ class CustomerSiteController extends Controller
     {
         $this->authorize('create', new CustomerSite);
         $availableVendors = Vendor::orderBy('name')->pluck('name', 'id');
+        $availableTypes = CustomerSiteType::orderBy('name')->pluck('name', 'id');
 
-        return view('customer_sites.create', compact('availableVendors'));
+        return view('customer_sites.create', compact('availableVendors','availableTypes'));
     }
 
     public function store(Request $request)
@@ -49,6 +51,7 @@ class CustomerSiteController extends Controller
             'name' => 'required|max:60',
             'url' => 'required|url|max:255',
             'vendor_id' => 'nullable|exists:vendors,id',
+            'type_id' => 'nullable|exists:customer_site_types,id',
         ]);
         $newCustomerSite['owner_id'] = auth()->id();
 

--- a/app/Http/Controllers/CustomerSiteController.php
+++ b/app/Http/Controllers/CustomerSiteController.php
@@ -89,8 +89,9 @@ class CustomerSiteController extends Controller
     {
         $this->authorize('update', $customerSite);
         $availableVendors = Vendor::orderBy('name')->pluck('name', 'id');
+        $availableTypes = CustomerSiteType::orderBy('name')->pluck('name', 'id');
 
-        return view('customer_sites.edit', compact('customerSite', 'availableVendors'));
+        return view('customer_sites.edit', compact('customerSite', 'availableVendors', 'availableTypes'));
     }
 
     public function update(Request $request, CustomerSite $customerSite)
@@ -99,8 +100,9 @@ class CustomerSiteController extends Controller
 
         $customerSiteData = $request->validate([
             'name' => 'required|max:60',
-            'url' => 'required|max:255',
+            'url' => 'required|url|max:255',
             'vendor_id' => 'nullable|exists:vendors,id',
+            'type_id' => 'nullable|exists:customer_site_types,id',
             'is_active' => 'required|in:0,1',
             'check_interval' => ['required', 'numeric', 'min:1', 'max:60'],
             'priority_code' => 'required|in:high,normal,low',

--- a/app/Http/Controllers/CustomerSiteController.php
+++ b/app/Http/Controllers/CustomerSiteController.php
@@ -47,7 +47,7 @@ class CustomerSiteController extends Controller
 
         $newCustomerSite = $request->validate([
             'name' => 'required|max:60',
-            'url' => 'required|max:255',
+            'url' => 'required|url|max:255',
             'vendor_id' => 'nullable|exists:vendors,id',
         ]);
         $newCustomerSite['owner_id'] = auth()->id();

--- a/app/Http/Controllers/MonitoringController.php
+++ b/app/Http/Controllers/MonitoringController.php
@@ -13,6 +13,7 @@ class MonitoringController extends Controller
         $customerSiteQuery = CustomerSite::query();
         $customerSiteQuery->where('is_active', 1);
         $customerSiteQuery->where('name', 'like', '%'.$request->get('q').'%');
+        $customerSiteQuery->orderBy('type_id');
         $customerSiteQuery->orderBy('name');
         $customerSiteQuery->where('owner_id', auth()->id());
         if ($vendorId = $request->get('vendor_id')) {

--- a/app/Http/Controllers/MonitoringController.php
+++ b/app/Http/Controllers/MonitoringController.php
@@ -28,6 +28,20 @@ class MonitoringController extends Controller
         $availableVendors = Vendor::orderBy('name')->pluck('name', 'id')->toArray();
         $availableVendors = ['null' => 'n/a'] + $availableVendors;
 
-        return view('monitoring.index', compact('customerSites', 'availableVendors'));
+        $theBlock = array();
+        $theCustomerSites = array();
+        foreach ($customerSites as $site) {
+            $theBlock[$site->type->name][] = $site;
+        }
+
+        foreach ($theBlock as $theEnv => $site) {
+            $theCustomerSites[] = [
+                'env' => $theEnv,
+                'data' => $site
+            ];
+        }
+
+        
+        return view('monitoring.index', compact('theCustomerSites', 'availableVendors'));
     }
 }

--- a/app/Jobs/RunCheck.php
+++ b/app/Jobs/RunCheck.php
@@ -82,7 +82,7 @@ class RunCheck implements ShouldQueue
                     ->where('customer_site_id', $customerSite->id)
                     ->orderBy('created_at', 'desc')
                     ->take(5)
-                    ->get(['response_time', 'status_code', 'visibility', 'created_at']);
+                    ->get(['response_time', 'status_code', 'created_at']);
                 
                 notifyTelegramUser($customerSite, $responseTimes, $notifyStatus);
                 $customerSite->last_notify_user_at = Carbon::now();

--- a/app/Jobs/RunCheck.php
+++ b/app/Jobs/RunCheck.php
@@ -37,7 +37,7 @@ class RunCheck implements ShouldQueue
             } else {
                 $customerSiteTimeout = 30;
             }
-            
+
             $response = Http::timeout($customerSiteTimeout)
                 ->connectTimeout(20)
                 ->get($customerSite->url);
@@ -77,7 +77,7 @@ class RunCheck implements ShouldQueue
                     ->take(5)
                     ->get(['response_time', 'status_code', 'created_at']);
                 
-                notifyTelegramUser($customerSite, $responseTimes);
+                notifyTelegramUser($customerSite, $responseTimes, "Down");
                 $customerSite->last_notify_user_at = Carbon::now();
                 $customerSite->save();
             }

--- a/app/Jobs/RunCheck.php
+++ b/app/Jobs/RunCheck.php
@@ -60,7 +60,7 @@ class RunCheck implements ShouldQueue
         $responseTime = round(($end - $start) * 1000); // Calculate response time in milliseconds
 
         // WHEN RESPONSE TIME ABOVE "DOWN" THRESHOLD, EVEN IF HTTP STATUS CODE IS 200, NOTIFY USER
-        if ($statusCode == 200 && $responseTime >= ($customerSite->down_threshold / 1000)) {
+        if ($statusCode == 200 && $responseTime >= $customerSite->down_threshold) {
             $force_notify = true;
             $notifyStatus = "Hit Down Threshold";
         }

--- a/app/Jobs/RunCheck.php
+++ b/app/Jobs/RunCheck.php
@@ -43,7 +43,7 @@ class RunCheck implements ShouldQueue
             }
         } catch (ConnectionException $e) {
             Log::channel('daily')->error($e);
-            $statusCode = 500;
+            $statusCode = 504;
             $force_notify = true;
         } catch (RequestException $e) {
             Log::channel('daily')->error($e);

--- a/app/Jobs/RunCheck.php
+++ b/app/Jobs/RunCheck.php
@@ -32,7 +32,12 @@ class RunCheck implements ShouldQueue
         $customerSite = $this->customerSite;
         $start = microtime(true);
         try {
-            $customerSiteTimeout = $customerSite->down_threshold / 1000;
+            if (config('queue.default') == 'sync') {
+                $customerSiteTimeout = $customerSite->down_threshold / 1000;
+            } else {
+                $customerSiteTimeout = 30;
+            }
+            
             $response = Http::timeout($customerSiteTimeout)
                 ->connectTimeout(20)
                 ->get($customerSite->url);

--- a/app/Jobs/RunCheck.php
+++ b/app/Jobs/RunCheck.php
@@ -82,7 +82,7 @@ class RunCheck implements ShouldQueue
                     ->where('customer_site_id', $customerSite->id)
                     ->orderBy('created_at', 'desc')
                     ->take(5)
-                    ->get(['response_time', 'status_code', 'created_at']);
+                    ->get(['response_time', 'status_code', 'visibility', 'created_at']);
                 
                 notifyTelegramUser($customerSite, $responseTimes, $notifyStatus);
                 $customerSite->last_notify_user_at = Carbon::now();

--- a/app/Models/CustomerSite.php
+++ b/app/Models/CustomerSite.php
@@ -11,7 +11,7 @@ class CustomerSite extends Model
     use HasFactory;
 
     protected $fillable = [
-        'name', 'url', 'vendor_id', 'is_active', 'owner_id', 'check_interval', 'priority_code',
+        'name', 'url', 'vendor_id', 'type_id', 'is_active', 'owner_id', 'check_interval', 'priority_code',
         'warning_threshold', 'down_threshold', 'notify_user_interval', 'last_check_at',
     ];
 
@@ -40,6 +40,11 @@ class CustomerSite extends Model
     public function vendor()
     {
         return $this->belongsTo(Vendor::class)->withDefault(['name' => 'n/a']);
+    }
+
+    public function type()
+    {
+        return $this->belongsTo(CustomerSiteType::class)->withDefault(['name' => 'n/a']);
     }
 
     public function needToCheck(): bool

--- a/app/Models/CustomerSiteType.php
+++ b/app/Models/CustomerSiteType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CustomerSiteType extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/CustomerSiteType.php
+++ b/app/Models/CustomerSiteType.php
@@ -8,4 +8,12 @@ use Illuminate\Database\Eloquent\Model;
 class CustomerSiteType extends Model
 {
     use HasFactory;
+
+    public function getHtmlSlugAttribute()
+    {
+        if (isset($this->attributes['slug'])) {
+            $slug = $this->attributes['slug'];
+            return "<span class='badge bg-primary'>$slug</span>";
+        }
+    }
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -26,7 +26,7 @@ if (!function_exists('notifyTelegramUser')) {
         $text .= "\n\nLast 5 response time:";
         $text .= "\n";
         foreach ($responseTimes as $responseTime) {
-            $text .= $responseTime->created_at->format('H:i:s').':   '.$responseTime->response_time.' ms';
+            $text .= "Code : $responseTime->status_code | " . $responseTime->created_at->format('H:i:s').':   '.$responseTime->response_time.' ms';
             $text .= "\n";
         }
         $text .= "\nCheck here:";

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Log;
 
 
 if (!function_exists('notifyTelegramUser')) {   
-    function notifyTelegramUser(CustomerSite $customerSite, Collection $responseTimes): void {
+    function notifyTelegramUser(CustomerSite $customerSite, Collection $responseTimes, $status = "Slow"): void {
         if (is_null($customerSite->owner)) {
             Log::channel('daily')->info('Missing customer site owner', $customerSite->toArray());
             return;
@@ -21,7 +21,7 @@ if (!function_exists('notifyTelegramUser')) {
 
         $endpoint = 'https://api.telegram.org/bot'.config('services.telegram_notifier.token').'/sendMessage';
         $text = "";
-        $text .= "Uptime: Website Down";
+        $text .= "Uptime: Website $status";
         $text .= "\n\n".$customerSite->name.' ('.$customerSite->url.')';
         $text .= "\n\nLast 5 response time:";
         $text .= "\n";

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Models\CustomerSite;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+
+if (!function_exists('notifyTelegramUser')) {   
+    function notifyTelegramUser(CustomerSite $customerSite, Collection $responseTimes): void {
+        if (is_null($customerSite->owner)) {
+            Log::channel('daily')->info('Missing customer site owner', $customerSite->toArray());
+            return;
+        }
+
+        $telegramChatId = $customerSite->owner->telegram_chat_id;
+        if (is_null($telegramChatId)) {
+            Log::channel('daily')->info('Missing telegram_chat_id form owner', $customerSite->toArray());
+            return;
+        }
+
+        $endpoint = 'https://api.telegram.org/bot'.config('services.telegram_notifier.token').'/sendMessage';
+        $text = "";
+        $text .= "Uptime: Website Down";
+        $text .= "\n\n".$customerSite->name.' ('.$customerSite->url.')';
+        $text .= "\n\nLast 5 response time:";
+        $text .= "\n";
+        foreach ($responseTimes as $responseTime) {
+            $text .= $responseTime->created_at->format('H:i:s').':   '.$responseTime->response_time.' ms';
+            $text .= "\n";
+        }
+        $text .= "\nCheck here:";
+        $text .= "\n".route('customer_sites.show', [$customerSite->id]);
+        Http::post($endpoint, [
+            'chat_id' => $telegramChatId,
+            'text' => $text,
+        ]);
+    }
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -30,7 +30,13 @@ if (!function_exists('notifyTelegramUser')) {
             $text .= "\n";
         }
         $text .= "\nCheck here:";
-        $text .= "\n".route('customer_sites.show', [$customerSite->id]);
+
+        if ($customerSite->visibility == "public") {
+            $text .= "\n".route('customer_sites.public-show', [$customerSite->id]);
+        } else {
+            $text .= "\n".route('customer_sites.show', [$customerSite->id]);
+        }
+
         Http::post($endpoint, [
             'chat_id' => $telegramChatId,
             'text' => $text,

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,10 @@
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
             "Database\\Seeders\\": "database/seeders/"
-        }
+        },
+        "files": [
+            "app/helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/database/migrations/2024_05_10_030731_create_user_preferences_table.php
+++ b/database/migrations/2024_05_10_030731_create_user_preferences_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('user_preferences', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedInteger('warning_threshold');
+            $table->unsignedInteger('down_threshold');
+            $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('user_preferences');
+    }
+};

--- a/database/migrations/2024_05_10_121858_create_customer_site_types_table.php
+++ b/database/migrations/2024_05_10_121858_create_customer_site_types_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Models\CustomerSiteType;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('customer_site_types', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug');
+            $table->timestamps();
+        });
+
+        CustomerSiteType::insert([
+            [
+                'name' => 'Production',
+                'slug' => 'prod',
+            ],
+            [
+                'name' => 'Development',
+                'slug' => 'dev',
+            ],
+            [
+                'name' => 'Staging',
+                'slug' => 'stg',
+            ]
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('customer_site_types');
+    }
+};

--- a/database/migrations/2024_05_10_122430_update_customer_sites_table.php
+++ b/database/migrations/2024_05_10_122430_update_customer_sites_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('customer_sites', function (Blueprint $table) {
+            $table->unsignedBigInteger('type_id')->nullable()->after('vendor_id');
+
+            $table->foreign('type_id')->references('id')->on('customer_site_types');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/database/migrations/2024_05_10_164155_update_customer_site_table.php
+++ b/database/migrations/2024_05_10_164155_update_customer_site_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('customer_sites', function (Blueprint $table) {
+            $table->string('visibility')->default('private')->after('last_notify_user_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/lang/en/customer_site.php
+++ b/lang/en/customer_site.php
@@ -3,6 +3,7 @@
 return [
     // Labels
     'customer_site' => 'Customer Site',
+    'type' => 'Site Type',
     'list' => 'Customer Site List',
     'search' => 'Search Customer Site',
     'search_text' => 'Title ...',

--- a/resources/views/customer_sites/create.blade.php
+++ b/resources/views/customer_sites/create.blade.php
@@ -14,10 +14,10 @@
                         {!! FormField::text('name', ['required' => true, 'label' => __('customer_site.name'), 'placeholder' => 'Example Web']) !!}
                     </div>
                     <div class="col-md-4">
-                        {!! FormField::select('vendor_id', $availableVendors, ['label' => __('vendor.vendor')]) !!}
+                        {!! FormField::select('vendor_id', $availableVendors, [ 'label' => __('vendor.vendor')]) !!}
                     </div>
                 </div>
-                {!! FormField::text('url', ['label' => __('customer_site.url'), 'placeholder' => 'https://example.net']) !!}
+                {!! FormField::text('url', ['required' => true, 'label' => __('customer_site.url'), 'placeholder' => 'https://example.net']) !!}
             </div>
             <div class="card-footer">
                 {{ Form::submit(__('app.create'), ['class' => 'btn btn-success']) }}

--- a/resources/views/customer_sites/create.blade.php
+++ b/resources/views/customer_sites/create.blade.php
@@ -16,6 +16,9 @@
                     <div class="col-md-4">
                         {!! FormField::select('vendor_id', $availableVendors, [ 'label' => __('vendor.vendor')]) !!}
                     </div>
+                    <div class="col-md-4">
+                        {!! FormField::select('type_id', $availableTypes, [ 'label' => __('customer_site.type')]) !!}
+                    </div>
                 </div>
                 {!! FormField::text('url', ['required' => true, 'label' => __('customer_site.url'), 'placeholder' => 'https://example.net']) !!}
             </div>

--- a/resources/views/customer_sites/edit.blade.php
+++ b/resources/views/customer_sites/edit.blade.php
@@ -43,8 +43,11 @@
                     <div class="col-md-4">
                         {!! FormField::select('vendor_id', $availableVendors, ['label' => __('vendor.vendor')]) !!}
                     </div>
+                    <div class="col-md-4">
+                        {!! FormField::select('type_id', $availableTypes, [ 'label' => __('customer_site.type')]) !!}
+                    </div>
                 </div>
-                {!! FormField::text('url', ['label' => __('customer_site.url')]) !!}
+                {!! FormField::text('url', ['required' => true, 'label' => __('customer_site.url')]) !!}
                 <div class="row">
                     <div class="col-md-5">
                         {!! FormField::text('check_interval', [

--- a/resources/views/customer_sites/index.blade.php
+++ b/resources/views/customer_sites/index.blade.php
@@ -36,6 +36,7 @@
                         <th>{{ __('customer_site.name') }}</th>
                         <th>{{ __('customer_site.url') }}</th>
                         <th>{{ __('vendor.vendor') }}</th>
+                        <th>{{ __('customer_site.type') }}</th>
                         <th class="text-center">{{ __('app.status') }}</th>
                         <th class="text-center">{{ __('app.action') }}</th>
                     </tr>
@@ -47,6 +48,7 @@
                         <td>{{ $customerSite->name }}</td>
                         <td><a target="_blank" href="{{ $customerSite->url }}">{{ $customerSite->url }}</a></td>
                         <td>{{ $customerSite->vendor->name }}</td>
+                        <td>{{ $customerSite->type->name }}</td>
                         <td class="text-center">{{ $customerSite->is_active }}</td>
                         <td class="text-center">
                             @can('view', $customerSite)

--- a/resources/views/layouts/customer_site.blade.php
+++ b/resources/views/layouts/customer_site.blade.php
@@ -22,6 +22,7 @@
                         <tr><td>{{ __('customer_site.name') }}</td><td>{{ $customerSite->name }}</td></tr>
                         <tr><td>{{ __('customer_site.url') }}</td><td><a target="_blank" href="{{ $customerSite->url }}">{{ $customerSite->url }}</a></td></tr>
                         <tr><td>{{ __('vendor.vendor') }}</td><td>{{ $customerSite->vendor->name }}</td></tr>
+                        <tr><td>{{ __('customer_site.type') }}</td><td>{{ $customerSite->type->name }}</td></tr>
                         <tr><td>{{ __('app.status') }}</td><td>{{ $customerSite->is_active }}</td></tr>
                         <tr>
                             <td>{{ __('customer_site.check_interval') }}</td>

--- a/resources/views/layouts/customer_site.blade.php
+++ b/resources/views/layouts/customer_site.blade.php
@@ -7,20 +7,24 @@
     <div class="col-md-4 order-2 order-md-1">
         <div class="card">
             <div class="card-header">
+                @auth
                 <div class="float-end">
                     {!! FormField::formButton(
                         ['route' => ['customer_sites.check_now', $customerSite->id]],
                         __('customer_site.check_now'),
                         ['class' => 'btn btn-success', 'id' => 'check_now_'.$customerSite->id]
-                    ) !!}
+                        ) !!}
                 </div>
+                @endauth
                 <h4 class="">{{ __('customer_site.customer_site') }}</h4>
             </div>
             <div class="card-body">
                 <table class="table table-sm">
                     <tbody>
                         <tr><td>{{ __('customer_site.name') }}</td><td>{{ $customerSite->name }}</td></tr>
+                        @auth
                         <tr><td>{{ __('customer_site.url') }}</td><td><a target="_blank" href="{{ $customerSite->url }}">{{ $customerSite->url }}</a></td></tr>
+                        @endauth
                         <tr><td>{{ __('vendor.vendor') }}</td><td>{{ $customerSite->vendor->name }}</td></tr>
                         <tr><td>{{ __('customer_site.type') }}</td><td>{{ $customerSite->type->name }}</td></tr>
                         <tr><td>{{ __('app.status') }}</td><td>{{ $customerSite->is_active }}</td></tr>
@@ -54,7 +58,9 @@
                 @can('update', $customerSite)
                     {{ link_to_route('customer_sites.edit', __('customer_site.edit'), [$customerSite], ['class' => 'btn btn-warning', 'id' => 'edit-customer_site-'.$customerSite->id]) }}
                 @endcan
+                @auth
                 {{ link_to_route('home', __('app.back_to_dashboard'), [], ['class' => 'btn btn-link']) }}
+                @endauth
             </div>
         </div>
     </div>
@@ -86,6 +92,7 @@
             </div>
         </div>
 
+        @auth 
         <ul class="nav nav-tabs">
             <li class="nav-item">
                 {{ link_to_route('customer_sites.show', __('monitoring_log.graph'), [$customerSite->id]+request(['time_range', 'start_time', 'end_time']), ['class' => 'nav-link '.(in_array(Request::segment(3), [null]) ? 'active' : '')]) }}
@@ -94,6 +101,16 @@
                 {{ link_to_route('customer_sites.timeline', __('monitoring_log.monitoring_log'), [$customerSite->id]+request(['time_range', 'start_time', 'end_time']), ['class' => 'nav-link '.(in_array(Request::segment(3), ['timeline']) ? 'active' : '')]) }}
             </li>
         </ul>
+        @else
+        <ul class="nav nav-tabs">
+            <li class="nav-item">
+                {{ link_to_route('customer_sites.public-show', __('monitoring_log.graph'), [$customerSite->id]+request(['time_range', 'start_time', 'end_time']), ['class' => 'nav-link '.(in_array(Request::segment(4), [null]) ? 'active' : '')]) }}
+            </li>
+            <li class="nav-item">
+                {{ link_to_route('customer_sites.public-timeline', __('monitoring_log.monitoring_log'), [$customerSite->id]+request(['time_range', 'start_time', 'end_time']), ['class' => 'nav-link '.(in_array(Request::segment(3), ['timeline']) ? 'active' : '')]) }}
+            </li>
+        </ul>
+        @endauth
 
         @yield('customer_site_content')
     </div>

--- a/resources/views/monitoring/index.blade.php
+++ b/resources/views/monitoring/index.blade.php
@@ -32,36 +32,44 @@
     </div>
 </div>
 <br>
+
+@foreach ($theCustomerSites as $customerSites)
 <div class="row mb-4">
-    @foreach ($customerSites as $customerSite)
-        <a href="{{ route('customer_sites.show', [$customerSite]) }}" class="col-md-6 col-lg-4 col-xl-3 px-1 mb-2 text-decoration-none">
-            <div class="card">
-                <div class="card-body py-2 px-3">
-                    <div class="row">
-                        <div class="col-6 px-1">
-                            {{ $customerSite->name }}
-                        </div>
-                        <div class="col-6 px-1 text-end">
-                            <div class="small" title="{{ __('customer_sites.check_interval') }}: {{ __('time.every') }} {{ $customerSite->check_interval }} {{ trans_choice('time.minutes', $customerSite->check_interval) }}">
-                                {{ $customerSite->check_interval }} {{ trans_choice('time.minutes', $customerSite->check_interval) }}
-                            </div>
-                            @livewire('uptime-badge', [
-                                'customerSite' => $customerSite,
-                                'uptimePoll' => request('uptime_poll', 0)
-                            ])
-                        </div>
+    <div class="row mb-2">
+        <div class="col-12">
+            <b>{{ $customerSites['env'] }}</b>
+        </div>
+    </div>
+    @foreach ($customerSites['data'] as $customerSite)
+    <a href="{{ route('customer_sites.show', [$customerSite]) }}" class="col-md-6 col-lg-4 col-xl-3 px-1 mb-2 text-decoration-none">
+        <div class="card">
+            <div class="card-body py-2 px-3">
+                <div class="row">
+                    <div class="col-6 px-1">
+                        {{ $customerSite->name }}
                     </div>
-                    <div class="row">
-                        <div class="col-12 px-1">
-                            <span class="badge bg-secondary">{{ $customerSite->vendor->name }}</span>
-                            {!! $customerSite->type->html_slug !!}
+                    <div class="col-6 px-1 text-end">
+                        <div class="small" title="{{ __('customer_sites.check_interval') }}: {{ __('time.every') }} {{ $customerSite->check_interval }} {{ trans_choice('time.minutes', $customerSite->check_interval) }}">
+                            {{ $customerSite->check_interval }} {{ trans_choice('time.minutes', $customerSite->check_interval) }}
                         </div>
+                        @livewire('uptime-badge', [
+                            'customerSite' => $customerSite,
+                            'uptimePoll' => request('uptime_poll', 0)
+                        ])
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-12 px-1">
+                        <span class="badge bg-secondary">{{ $customerSite->vendor->name }}</span>
+                        {!! $customerSite->type->html_slug !!}
                     </div>
                 </div>
             </div>
-        </a>
+        </div>
+    </a>
     @endforeach
 </div>
+@endforeach
 @endsection
 
 @push('styles')

--- a/resources/views/monitoring/index.blade.php
+++ b/resources/views/monitoring/index.blade.php
@@ -39,8 +39,7 @@
                 <div class="card-body py-2 px-3">
                     <div class="row">
                         <div class="col-6 px-1">
-                            {{ $customerSite->name }}<br>
-                            <span class="badge bg-secondary">{{ $customerSite->vendor->name }}</span>
+                            {{ $customerSite->name }}
                         </div>
                         <div class="col-6 px-1 text-end">
                             <div class="small" title="{{ __('customer_sites.check_interval') }}: {{ __('time.every') }} {{ $customerSite->check_interval }} {{ trans_choice('time.minutes', $customerSite->check_interval) }}">
@@ -50,6 +49,12 @@
                                 'customerSite' => $customerSite,
                                 'uptimePoll' => request('uptime_poll', 0)
                             ])
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-12 px-1">
+                            <span class="badge bg-secondary">{{ $customerSite->vendor->name }}</span>
+                            {!! $customerSite->type->html_slug !!}
                         </div>
                     </div>
                 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -34,6 +34,10 @@ Route::group(['middleware' => ['auth']], function () {
     Route::patch('profile/update', [ProfileController::class, 'update'])->name('profile.update');
 });
 
+// PUBLIC ROUTE
+Route::get('public/monitor/{customer_site}', [CustomerSiteController::class, 'public_view'])->name('customer_sites.public-show');
+Route::get('public/monitor/{customer_site}/timeline', [CustomerSiteController::class, 'timeline'])->name('customer_sites.public-timeline');
+
 /*
  * Vendors Routes
  */


### PR DESCRIPTION
Hello, 
First of all, thanks for your great open source project. I've tried this awesome project and determine to adjust some part of this project, and minor UI change update.

UI Related update : 
1. Adding Website Type (Production, Development, Staging) 
2. Adding Website URL validation to make sure website address is valid
3. Split website card on dashboard page base on website type

Notification Related Update :
- Make sure to notfiy user as soon as possible when their website returning http status code other than 200.
- Adjust timeout mechanism to max 30 seconds when "uptime monitor" queue connection use supported async driver. With this update, we try to catch the real reponse time from a website instead of capping their timeout as "down" threshold. Even though, the hardcoded max 30 second timeout  is needed.
- Adding 3 basic uptime notification status as stated below :

`1. Down Status`
This notification send to user within 3 condition :
1.1. When the actual website http response code returning other than code 200.
1.2. When actual site check is timeout (recorded as http code 504)
1.3 When the average of last 5 response time above 90% of "down threshold" and the latest website response log has http response code other than 200

`2. Slow Status`
This notification send to user w hen avg response time of single website above 90% of "down threshold" during notify "command" check.

`3. Hit Down Threshold`
This notification send to user when the actual site check response time exceed "down threshold" but still below 30 second hardcoded time out, and returning http code 200.

All notification sended to user still consider the waiting notification interval before send another notification (not changed)

That's all from me, hope this change can help someone with the same idea or use case with me. Even if this PR not pulled, i hope someday we can adjust this project with more flexible notification strategy and dynamic "down" detection. Thanks