### PR TITLE
Add Docker environment via Laravel Sail

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,38 @@ In order to get notified in Telegram when the customer sites are down, we need t
     - Set the Notify User Interval field, between 0 to 60.
     - Set the Notify User Interval field to 0 if you don't want to get notified.
 
+## Docker with Laravel Sail
+
+This application supports development using [Laravel Sail](https://laravel.com/docs/10.x/sail), the official Docker environment for Laravel.
+
+### Usage Steps
+
+1. Make sure you have [Docker](https://www.docker.com/products/docker-desktop) installed.
+2. Copy `.env.example` to `.env` if you haven't already.
+3. Install PHP dependencies (only once):
+    ```
+    composer install
+    ```
+4. Build and start the containers:
+    ```
+    bash ./vendor/bin/sail up
+    ```
+5. Run migrations and seeders:
+    ```
+    bash ./vendor/bin/sail artisan migrate --seed
+    ```
+6. Install JavaScript dependencies and build assets:
+    ```
+    ./vendor/bin/sail npm install
+    ./vendor/bin/sail npm run build
+    ```
+7. Run the scheduler worker:
+    ```
+    ./vendor/bin/sail artisan schedule:work
+    ```
+8. Access the application at [http://localhost](http://localhost).
+
+
 ## Screenshot
 
 #### Dashboard

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,56 @@
+services:
+    laravel.test:
+        build:
+            context: './vendor/laravel/sail/runtimes/8.4'
+            dockerfile: Dockerfile
+            args:
+                WWWGROUP: '${WWWGROUP}'
+                MYSQL_CLIENT: mariadb-client
+        image: 'sail-8.4/app'
+        extra_hosts:
+            - 'host.docker.internal:host-gateway'
+        ports:
+            - '${APP_PORT:-80}:80'
+            - '${VITE_PORT:-5173}:${VITE_PORT:-5173}'
+        environment:
+            WWWUSER: '${WWWUSER}'
+            LARAVEL_SAIL: 1
+            XDEBUG_MODE: '${SAIL_XDEBUG_MODE:-off}'
+            XDEBUG_CONFIG: '${SAIL_XDEBUG_CONFIG:-client_host=host.docker.internal}'
+            IGNITION_LOCAL_SITES_PATH: '${PWD}'
+        volumes:
+            - '.:/var/www/html'
+        networks:
+            - sail
+        depends_on:
+            - mariadb
+    mariadb:
+        image: 'mariadb:11'
+        ports:
+            - '${FORWARD_DB_PORT:-3306}:3306'
+        environment:
+            MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
+            MYSQL_ROOT_HOST: '%'
+            MYSQL_DATABASE: '${DB_DATABASE}'
+            MYSQL_USER: '${DB_USERNAME}'
+            MYSQL_PASSWORD: '${DB_PASSWORD}'
+            MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+        volumes:
+            - 'sail-mariadb:/var/lib/mysql'
+            - './vendor/laravel/sail/database/mariadb/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'
+        networks:
+            - sail
+        healthcheck:
+            test:
+                - CMD
+                - healthcheck.sh
+                - '--connect'
+                - '--innodb_initialized'
+            retries: 3
+            timeout: 5s
+networks:
+    sail:
+        driver: bridge
+volumes:
+    sail-mariadb:
+        driver: local


### PR DESCRIPTION
## Summary

Add a first-class Docker-based local environment using Laravel Sail. No app logic or database write behavior is changed.

## Context / Why

Standardized containers simplify onboarding and ensure environment parity (PHP, DB) without bespoke local setup.

## Changes

### Dev environment (Laravel Sail)
- Add `docker-compose.yml` with services:
  - `laravel.test` (app), `mariadb` (database)
- Configure port forwards:
  - App: `${APP_PORT:-80}:80`, Vite: `${VITE_PORT:-5173}`
  - DB: `${FORWARD_DB_PORT:-3306}:3306`
- `.env.example` alignment for Sail:
  - `DB_HOST=mariadb`, `DB_USERNAME=sail`, `DB_PASSWORD=password` (example defaults)
- Docs snippet in README for running with `./vendor/bin/sail` or `docker compose`

## What’s NOT included

* No database schema changes
* No changes to create/update logic
* No queue/scheduler services (can be added later)
