### PR TITLE
Standardize UI to Bootstrap 5

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,73 +1,79 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">{{ __('Login') }}</div>
+    <div class="container py-4">
+        <div class="row justify-content-center">
+            <div class="col-md-8">
+                <div class="card shadow-sm">
+                    <div class="card-header">{{ __('Login') }}</div>
 
-                <div class="card-body">
-                    <form method="POST" action="{{ route('login') }}">
-                        @csrf
+                    <div class="card-body">
+                        <form method="POST" action="{{ route('login') }}">
+                            @csrf
 
-                        <div class="row mb-3">
-                            <label for="email" class="col-md-4 col-form-label text-md-end">{{ __('Email Address') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="email" type="email" class="form-control @error('email') is-invalid @enderror" name="email" value="{{ old('email') }}" required autocomplete="email" autofocus>
-
-                                @error('email')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
-                            </div>
-                        </div>
-
-                        <div class="row mb-3">
-                            <label for="password" class="col-md-4 col-form-label text-md-end">{{ __('Password') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="password" type="password" class="form-control @error('password') is-invalid @enderror" name="password" required autocomplete="current-password">
-
-                                @error('password')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
-                            </div>
-                        </div>
-
-                        <div class="row mb-3">
-                            <div class="col-md-6 offset-md-4">
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" name="remember" id="remember" {{ old('remember') ? 'checked' : '' }}>
-
-                                    <label class="form-check-label" for="remember">
-                                        {{ __('Remember Me') }}
-                                    </label>
+                            {{-- Email --}}
+                            <div class="row mb-3">
+                                <label for="email"
+                                    class="col-md-4 col-form-label text-md-end">{{ __('Email Address') }}</label>
+                                <div class="col-md-6">
+                                    <input id="email" type="email"
+                                        class="form-control @error('email') is-invalid @enderror" name="email"
+                                        value="{{ old('email') }}" required autocomplete="email" autofocus>
+                                    @error('email')
+                                        <div class="invalid-feedback" role="alert">
+                                            <strong>{{ $message }}</strong>
+                                        </div>
+                                    @enderror
                                 </div>
                             </div>
-                        </div>
 
-                        <div class="row mb-0">
-                            <div class="col-md-8 offset-md-4">
-                                <button type="submit" class="btn btn-primary">
-                                    {{ __('Login') }}
-                                </button>
-
-                                @if (Route::has('password.request'))
-                                    <a class="btn btn-link" href="{{ route('password.request') }}">
-                                        {{ __('Forgot Your Password?') }}
-                                    </a>
-                                @endif
+                            {{-- Password --}}
+                            <div class="row mb-3">
+                                <label for="password"
+                                    class="col-md-4 col-form-label text-md-end">{{ __('Password') }}</label>
+                                <div class="col-md-6">
+                                    <input id="password" type="password"
+                                        class="form-control @error('password') is-invalid @enderror" name="password"
+                                        required autocomplete="current-password">
+                                    @error('password')
+                                        <div class="invalid-feedback" role="alert">
+                                            <strong>{{ $message }}</strong>
+                                        </div>
+                                    @enderror
+                                </div>
                             </div>
-                        </div>
-                    </form>
+
+                            {{-- Remember Me --}}
+                            <div class="row mb-3">
+                                <div class="col-md-6 offset-md-4">
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="checkbox" name="remember" id="remember"
+                                            {{ old('remember') ? 'checked' : '' }}>
+                                        <label class="form-check-label" for="remember">
+                                            {{ __('Remember Me') }}
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+
+                            {{-- Actions --}}
+                            <div class="row mb-0">
+                                <div class="col-md-8 offset-md-4 d-flex gap-2 align-items-center">
+                                    <button type="submit" class="btn btn-primary">
+                                        {{ __('Login') }}
+                                    </button>
+
+                                    @if (Route::has('password.request'))
+                                        <a class="btn btn-link p-0" href="{{ route('password.request') }}">
+                                            {{ __('Forgot Your Password?') }}
+                                        </a>
+                                    @endif
+                                </div>
+                            </div>
+                        </form>
+                    </div> {{-- /.card-body --}}
                 </div>
             </div>
         </div>
     </div>
-</div>
 @endsection

--- a/resources/views/auth/passwords/confirm.blade.php
+++ b/resources/views/auth/passwords/confirm.blade.php
@@ -1,49 +1,50 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">{{ __('Confirm Password') }}</div>
+    <div class="container py-4">
+        <div class="row justify-content-center">
+            <div class="col-md-8">
+                <div class="card shadow-sm">
+                    <div class="card-header">{{ __('Confirm Password') }}</div>
 
-                <div class="card-body">
-                    {{ __('Please confirm your password before continuing.') }}
+                    <div class="card-body">
+                        <p class="mb-3">{{ __('Please confirm your password before continuing.') }}</p>
 
-                    <form method="POST" action="{{ route('password.confirm') }}">
-                        @csrf
+                        <form method="POST" action="{{ route('password.confirm') }}">
+                            @csrf
 
-                        <div class="row mb-3">
-                            <label for="password" class="col-md-4 col-form-label text-md-end">{{ __('Password') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="password" type="password" class="form-control @error('password') is-invalid @enderror" name="password" required autocomplete="current-password">
-
-                                @error('password')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
+                            <div class="row mb-3">
+                                <label for="password"
+                                    class="col-md-4 col-form-label text-md-end">{{ __('Password') }}</label>
+                                <div class="col-md-6">
+                                    <input id="password" type="password"
+                                        class="form-control @error('password') is-invalid @enderror" name="password"
+                                        required autocomplete="current-password">
+                                    @error('password')
+                                        <div class="invalid-feedback" role="alert">
+                                            <strong>{{ $message }}</strong>
+                                        </div>
+                                    @enderror
+                                </div>
                             </div>
-                        </div>
 
-                        <div class="row mb-0">
-                            <div class="col-md-8 offset-md-4">
-                                <button type="submit" class="btn btn-primary">
-                                    {{ __('Confirm Password') }}
-                                </button>
+                            <div class="row mb-0">
+                                <div class="col-md-8 offset-md-4 d-flex gap-2 align-items-center">
+                                    <button type="submit" class="btn btn-primary">
+                                        {{ __('Confirm Password') }}
+                                    </button>
 
-                                @if (Route::has('password.request'))
-                                    <a class="btn btn-link" href="{{ route('password.request') }}">
-                                        {{ __('Forgot Your Password?') }}
-                                    </a>
-                                @endif
+                                    @if (Route::has('password.request'))
+                                        <a class="btn btn-link p-0" href="{{ route('password.request') }}">
+                                            {{ __('Forgot Your Password?') }}
+                                        </a>
+                                    @endif
+                                </div>
                             </div>
-                        </div>
-                    </form>
+                        </form>
+                    </div> {{-- /.card-body --}}
                 </div>
             </div>
         </div>
     </div>
-</div>
 @endsection

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -1,47 +1,51 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">{{ __('Reset Password') }}</div>
+    <div class="container py-4">
+        <div class="row justify-content-center">
+            <div class="col-md-8">
+                <div class="card shadow-sm">
+                    <div class="card-header">{{ __('Reset Password') }}</div>
 
-                <div class="card-body">
-                    @if (session('status'))
-                        <div class="alert alert-success" role="alert">
-                            {{ session('status') }}
-                        </div>
-                    @endif
-
-                    <form method="POST" action="{{ route('password.email') }}">
-                        @csrf
-
-                        <div class="row mb-3">
-                            <label for="email" class="col-md-4 col-form-label text-md-end">{{ __('Email Address') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="email" type="email" class="form-control @error('email') is-invalid @enderror" name="email" value="{{ old('email') }}" required autocomplete="email" autofocus>
-
-                                @error('email')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
+                    <div class="card-body">
+                        @if (session('status'))
+                            <div class="alert alert-success" role="alert">
+                                {{ session('status') }}
                             </div>
-                        </div>
+                        @endif
 
-                        <div class="row mb-0">
-                            <div class="col-md-6 offset-md-4">
-                                <button type="submit" class="btn btn-primary">
-                                    {{ __('Send Password Reset Link') }}
-                                </button>
+                        <form method="POST" action="{{ route('password.email') }}">
+                            @csrf
+
+                            {{-- Email --}}
+                            <div class="row mb-3">
+                                <label for="email" class="col-md-4 col-form-label text-md-end">
+                                    {{ __('Email Address') }}
+                                </label>
+                                <div class="col-md-6">
+                                    <input id="email" type="email" name="email" value="{{ old('email') }}" required
+                                        autocomplete="email" autofocus
+                                        class="form-control @error('email') is-invalid @enderror">
+                                    @error('email')
+                                        <div class="invalid-feedback" role="alert">
+                                            <strong>{{ $message }}</strong>
+                                        </div>
+                                    @enderror
+                                </div>
                             </div>
-                        </div>
-                    </form>
+
+                            {{-- Actions --}}
+                            <div class="row mb-0">
+                                <div class="col-md-6 offset-md-4">
+                                    <button type="submit" class="btn btn-primary">
+                                        {{ __('Send Password Reset Link') }}
+                                    </button>
+                                </div>
+                            </div>
+                        </form>
+                    </div> {{-- /.card-body --}}
                 </div>
             </div>
         </div>
     </div>
-</div>
 @endsection

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -1,65 +1,81 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">{{ __('Reset Password') }}</div>
+    <div class="container py-4">
+        <div class="row justify-content-center">
+            <div class="col-md-8">
+                <div class="card shadow-sm">
+                    <div class="card-header">{{ __('Reset Password') }}</div>
 
-                <div class="card-body">
-                    <form method="POST" action="{{ route('password.update') }}">
-                        @csrf
+                    <div class="card-body">
+                        <form method="POST" action="{{ route('password.update') }}">
+                            @csrf
 
-                        <input type="hidden" name="token" value="{{ $token }}">
+                            <input type="hidden" name="token" value="{{ $token }}">
 
-                        <div class="row mb-3">
-                            <label for="email" class="col-md-4 col-form-label text-md-end">{{ __('Email Address') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="email" type="email" class="form-control @error('email') is-invalid @enderror" name="email" value="{{ $email ?? old('email') }}" required autocomplete="email" autofocus>
-
-                                @error('email')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
+                            {{-- Email --}}
+                            <div class="row mb-3">
+                                <label for="email" class="col-md-4 col-form-label text-md-end">
+                                    {{ __('Email Address') }}
+                                </label>
+                                <div class="col-md-6">
+                                    <input id="email" type="email"
+                                        class="form-control @error('email') is-invalid @enderror" name="email"
+                                        value="{{ $email ?? old('email') }}" required autocomplete="email" autofocus>
+                                    @error('email')
+                                        <div class="invalid-feedback" role="alert">
+                                            <strong>{{ $message }}</strong>
+                                        </div>
+                                    @enderror
+                                </div>
                             </div>
-                        </div>
 
-                        <div class="row mb-3">
-                            <label for="password" class="col-md-4 col-form-label text-md-end">{{ __('Password') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="password" type="password" class="form-control @error('password') is-invalid @enderror" name="password" required autocomplete="new-password">
-
-                                @error('password')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
+                            {{-- Password --}}
+                            <div class="row mb-3">
+                                <label for="password" class="col-md-4 col-form-label text-md-end">
+                                    {{ __('Password') }}
+                                </label>
+                                <div class="col-md-6">
+                                    <input id="password" type="password"
+                                        class="form-control @error('password') is-invalid @enderror" name="password"
+                                        required autocomplete="new-password">
+                                    @error('password')
+                                        <div class="invalid-feedback" role="alert">
+                                            <strong>{{ $message }}</strong>
+                                        </div>
+                                    @enderror
+                                </div>
                             </div>
-                        </div>
 
-                        <div class="row mb-3">
-                            <label for="password-confirm" class="col-md-4 col-form-label text-md-end">{{ __('Confirm Password') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required autocomplete="new-password">
+                            {{-- Confirm Password --}}
+                            <div class="row mb-3">
+                                <label for="password-confirm" class="col-md-4 col-form-label text-md-end">
+                                    {{ __('Confirm Password') }}
+                                </label>
+                                <div class="col-md-6">
+                                    <input id="password-confirm" type="password"
+                                        class="form-control @error('password_confirmation') is-invalid @enderror"
+                                        name="password_confirmation" required autocomplete="new-password">
+                                    @error('password_confirmation')
+                                        <div class="invalid-feedback" role="alert">
+                                            <strong>{{ $message }}</strong>
+                                        </div>
+                                    @enderror
+                                </div>
                             </div>
-                        </div>
 
-                        <div class="row mb-0">
-                            <div class="col-md-6 offset-md-4">
-                                <button type="submit" class="btn btn-primary">
-                                    {{ __('Reset Password') }}
-                                </button>
+                            {{-- Actions --}}
+                            <div class="row mb-0">
+                                <div class="col-md-6 offset-md-4 d-flex align-items-center">
+                                    <button type="submit" class="btn btn-primary">
+                                        {{ __('Reset Password') }}
+                                    </button>
+                                </div>
                             </div>
-                        </div>
-                    </form>
+                        </form>
+                    </div> {{-- /.card-body --}}
                 </div>
             </div>
         </div>
     </div>
-</div>
 @endsection

--- a/resources/views/auth/profile/edit.blade.php
+++ b/resources/views/auth/profile/edit.blade.php
@@ -1,29 +1,38 @@
 @extends('layouts.app')
 
-
 @section('content')
-<div class="row">
-    <div class="col-md-6 offset-md-3">
-        <div class="page-header"><h1 class="page-title">{{ __('user.profile_edit') }}</h1></div>
-        <div class="card">
-            {{ Form::model($user, ['route' => 'profile.update', 'method' => 'patch']) }}
-                <div class="card-body">
-                    {!! FormField::text('name', ['required' => true, 'label' => __('user.name')]) !!}
-                    <div class="row">
-                        <div class="col-md-6">
-                            {!! FormField::email('email', ['required' => true, 'label' => __('user.email')]) !!}
-                        </div>
-                        <div class="col-md-6">
-                            {!! FormField::text('telegram_chat_id', ['label' => __('user.telegram_chat_id')]) !!}
+    <div class="container py-4">
+        <div class="row justify-content-center">
+            <div class="col-md-8">
+
+                {{-- Heading --}}
+                <div class="d-flex align-items-center justify-content-between mb-3">
+                    <h1 class="h4 mb-0">{{ __('user.profile_edit') }}</h1>
+                </div>
+
+                <div class="card shadow-sm">
+                    {{ Form::model($user, ['route' => 'profile.update', 'method' => 'patch']) }}
+                    <div class="card-body">
+                        {!! FormField::text('name', ['required' => true, 'label' => __('user.name')]) !!}
+
+                        <div class="row g-3">
+                            <div class="col-md-6">
+                                {!! FormField::email('email', ['required' => true, 'label' => __('user.email')]) !!}
+                            </div>
+                            <div class="col-md-6">
+                                {!! FormField::text('telegram_chat_id', ['label' => __('user.telegram_chat_id')]) !!}
+                            </div>
                         </div>
                     </div>
+
+                    <div class="card-footer d-flex justify-content-end gap-2">
+                        {{ Form::submit(__('user.profile_update'), ['class' => 'btn btn-warning']) }}
+                        {{ link_to_route('profile.show', __('app.cancel'), [], ['class' => 'btn btn-link']) }}
+                    </div>
+                    {{ Form::close() }}
                 </div>
-                <div class="card-footer">
-                    {{ Form::submit(__('user.profile_update'), ['class' => 'btn btn-warning']) }}
-                    {{ link_to_route('profile.show', __('app.cancel'), [], ['class' => 'btn btn-link']) }}
-                </div>
-            {{ Form::close() }}
+
+            </div>
         </div>
     </div>
-</div>
 @endsection

--- a/resources/views/auth/profile/show.blade.php
+++ b/resources/views/auth/profile/show.blade.php
@@ -1,32 +1,46 @@
 @extends('layouts.app')
 
 @section('content')
+    <div class="container py-4">
+        <div class="row justify-content-center">
+            <div class="col-md-8">
 
-<div class="row">
-    <div class="col-md-6 offset-md-3">
-        <div class="page-header">
-            <h1 class="page-title">{{  __('user.profile').' - '.$user->name }}</h1>
-        </div>
-        <div class="card">
-            <table class="table table-sm card-table mb-0">
-                <tbody>
-                    <tr><td class="col-md-3">{{ __('user.name') }}</td><td class="col-md-9">{{ $user->name }}</td></tr>
-                    <tr><td>{{ __('user.email') }}</td><td>{{ $user->email }}</td></tr>
-                    <tr>
-                        <td class="align-middle">{{ __('user.telegram_chat_id') }}</td>
-                        <td class="align-middle">
-                            {{ $user->telegram_chat_id }}
-                            @if (config('services.telegram_notifier.token') && $user->telegram_chat_id)
-                                @livewire('telegram-test-button')
-                            @endif
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-            <div class="card-footer">
-                {{ link_to_route('profile.edit', __('user.profile_edit'), [], ['class' => 'btn btn-warning']) }}
+                {{-- Heading --}}
+                <div class="d-flex align-items-center justify-content-between mb-3">
+                    <h1 class="h4 mb-0">{{ __('user.profile') . ' - ' . $user->name }}</h1>
+                </div>
+
+                <div class="card shadow-sm">
+                    <div class="table-responsive">
+                        <table class="table table-sm mb-0 align-middle">
+                            <tbody>
+                                <tr>
+                                    <th class="w-25 text-muted">{{ __('user.name') }}</th>
+                                    <td class="w-75">{{ $user->name }}</td>
+                                </tr>
+                                <tr>
+                                    <th class="text-muted">{{ __('user.email') }}</th>
+                                    <td>{{ $user->email }}</td>
+                                </tr>
+                                <tr>
+                                    <th class="align-middle text-muted">{{ __('user.telegram_chat_id') }}</th>
+                                    <td class="align-middle">
+                                        {{ $user->telegram_chat_id }}
+                                        @if (config('services.telegram_notifier.token') && $user->telegram_chat_id)
+                                            @livewire('telegram-test-button')
+                                        @endif
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div class="card-footer d-flex justify-content-end">
+                        {{ link_to_route('profile.edit', __('user.profile_edit'), [], ['class' => 'btn btn-warning']) }}
+                    </div>
+                </div>
+
             </div>
         </div>
     </div>
-</div>
 @endsection

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,77 +1,91 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">{{ __('Register') }}</div>
+    <div class="container py-4">
+        <div class="row justify-content-center">
+            <div class="col-md-8">
+                <div class="card shadow-sm">
+                    <div class="card-header">{{ __('Register') }}</div>
 
-                <div class="card-body">
-                    <form method="POST" action="{{ route('register') }}">
-                        @csrf
+                    <div class="card-body">
+                        <form method="POST" action="{{ route('register') }}">
+                            @csrf
 
-                        <div class="row mb-3">
-                            <label for="name" class="col-md-4 col-form-label text-md-end">{{ __('Name') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="name" type="text" class="form-control @error('name') is-invalid @enderror" name="name" value="{{ old('name') }}" required autocomplete="name" autofocus>
-
-                                @error('name')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
+                            {{-- Name --}}
+                            <div class="row mb-3">
+                                <label for="name" class="col-md-4 col-form-label text-md-end">{{ __('Name') }}</label>
+                                <div class="col-md-6">
+                                    <input id="name" type="text"
+                                        class="form-control @error('name') is-invalid @enderror" name="name"
+                                        value="{{ old('name') }}" required autocomplete="name" autofocus>
+                                    @error('name')
+                                        <div class="invalid-feedback" role="alert">
+                                            <strong>{{ $message }}</strong>
+                                        </div>
+                                    @enderror
+                                </div>
                             </div>
-                        </div>
 
-                        <div class="row mb-3">
-                            <label for="email" class="col-md-4 col-form-label text-md-end">{{ __('Email Address') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="email" type="email" class="form-control @error('email') is-invalid @enderror" name="email" value="{{ old('email') }}" required autocomplete="email">
-
-                                @error('email')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
+                            {{-- Email --}}
+                            <div class="row mb-3">
+                                <label for="email"
+                                    class="col-md-4 col-form-label text-md-end">{{ __('Email Address') }}</label>
+                                <div class="col-md-6">
+                                    <input id="email" type="email"
+                                        class="form-control @error('email') is-invalid @enderror" name="email"
+                                        value="{{ old('email') }}" required autocomplete="email">
+                                    @error('email')
+                                        <div class="invalid-feedback" role="alert">
+                                            <strong>{{ $message }}</strong>
+                                        </div>
+                                    @enderror
+                                </div>
                             </div>
-                        </div>
 
-                        <div class="row mb-3">
-                            <label for="password" class="col-md-4 col-form-label text-md-end">{{ __('Password') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="password" type="password" class="form-control @error('password') is-invalid @enderror" name="password" required autocomplete="new-password">
-
-                                @error('password')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
+                            {{-- Password --}}
+                            <div class="row mb-3">
+                                <label for="password"
+                                    class="col-md-4 col-form-label text-md-end">{{ __('Password') }}</label>
+                                <div class="col-md-6">
+                                    <input id="password" type="password"
+                                        class="form-control @error('password') is-invalid @enderror" name="password"
+                                        required autocomplete="new-password">
+                                    @error('password')
+                                        <div class="invalid-feedback" role="alert">
+                                            <strong>{{ $message }}</strong>
+                                        </div>
+                                    @enderror
+                                </div>
                             </div>
-                        </div>
 
-                        <div class="row mb-3">
-                            <label for="password-confirm" class="col-md-4 col-form-label text-md-end">{{ __('Confirm Password') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required autocomplete="new-password">
+                            {{-- Confirm Password --}}
+                            <div class="row mb-3">
+                                <label for="password-confirm"
+                                    class="col-md-4 col-form-label text-md-end">{{ __('Confirm Password') }}</label>
+                                <div class="col-md-6">
+                                    <input id="password-confirm" type="password"
+                                        class="form-control @error('password_confirmation') is-invalid @enderror"
+                                        name="password_confirmation" required autocomplete="new-password">
+                                    @error('password_confirmation')
+                                        <div class="invalid-feedback" role="alert">
+                                            <strong>{{ $message }}</strong>
+                                        </div>
+                                    @enderror
+                                </div>
                             </div>
-                        </div>
 
-                        <div class="row mb-0">
-                            <div class="col-md-6 offset-md-4">
-                                <button type="submit" class="btn btn-primary">
-                                    {{ __('Register') }}
-                                </button>
+                            {{-- Actions --}}
+                            <div class="row mb-0">
+                                <div class="col-md-6 offset-md-4">
+                                    <button type="submit" class="btn btn-primary">
+                                        {{ __('Register') }}
+                                    </button>
+                                </div>
                             </div>
-                        </div>
-                    </form>
+                        </form>
+                    </div> {{-- /.card-body --}}
                 </div>
             </div>
         </div>
     </div>
-</div>
 @endsection

--- a/resources/views/auth/verify.blade.php
+++ b/resources/views/auth/verify.blade.php
@@ -1,28 +1,34 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">{{ __('Verify Your Email Address') }}</div>
+    <div class="container py-4">
+        <div class="row justify-content-center">
+            <div class="col-md-8">
+                <div class="card shadow-sm">
+                    <div class="card-header">{{ __('Verify Your Email Address') }}</div>
 
-                <div class="card-body">
-                    @if (session('resent'))
-                        <div class="alert alert-success" role="alert">
-                            {{ __('A fresh verification link has been sent to your email address.') }}
-                        </div>
-                    @endif
+                    <div class="card-body">
+                        @if (session('resent'))
+                            <div class="alert alert-success" role="alert">
+                                {{ __('A fresh verification link has been sent to your email address.') }}
+                            </div>
+                        @endif
 
-                    {{ __('Before proceeding, please check your email for a verification link.') }}
-                    {{ __('If you did not receive the email') }},
-                    <form class="d-inline" method="POST" action="{{ route('verification.resend') }}">
-                        @csrf
-                        <button type="submit" class="btn btn-link p-0 m-0 align-baseline">{{ __('click here to request another') }}</button>.
-                    </form>
+                        <p class="mb-2">
+                            {{ __('Before proceeding, please check your email for a verification link.') }}
+                        </p>
+                        <p class="mb-0">
+                            {{ __('If you did not receive the email') }},
+                        <form class="d-inline" method="POST" action="{{ route('verification.resend') }}">
+                            @csrf
+                            <button type="submit" class="btn btn-link p-0 align-baseline">
+                                {{ __('click here to request another') }}
+                            </button>
+                        </form>.
+                        </p>
+                    </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
 @endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,5 +1,6 @@
 <!doctype html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -13,73 +14,102 @@
     <link rel="dns-prefetch" href="//fonts.bunny.net">
     <link href="https://fonts.bunny.net/css?family=Nunito" rel="stylesheet">
 
-    <!-- Scripts -->
+    <!-- Scripts / Styles -->
     @vite(['resources/sass/app.scss', 'resources/js/app.js'])
     @stack('styles')
     @livewireStyles
 </head>
+
 <body>
     <div id="app">
-        <nav class="navbar navbar-expand-md navbar-light bg-white shadow-sm">
+        <nav class="navbar navbar-expand-md navbar-light bg-white border-bottom shadow-sm">
             <div class="container">
                 <a class="navbar-brand" href="{{ url('/') }}">
                     {{ config('app.name', 'Laravel') }}
                 </a>
-                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="{{ __('Toggle navigation') }}">
+
+                <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
+                    data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
+                    aria-expanded="false" aria-label="{{ __('Toggle navigation') }}">
                     <span class="navbar-toggler-icon"></span>
                 </button>
 
                 <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                    <!-- Left Side Of Navbar -->
+                    <!-- Left Side -->
                     <ul class="navbar-nav me-auto">
                         @auth
                             <li class="nav-item">
-                                <a class="nav-link" href="{{ route('home') }}">Dashboard</a>
+                                <a class="nav-link {{ request()->routeIs('home') ? 'active' : '' }}"
+                                    href="{{ route('home') }}" @if (request()->routeIs('home')) aria-current="page" @endif>
+                                    Dashboard
+                                </a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link" href="{{ route('sites.index') }}">{{ __('site.site') }}</a>
+                                <a class="nav-link {{ request()->routeIs('sites.*') ? 'active' : '' }}"
+                                    href="{{ route('sites.index') }}">
+                                    {{ __('site.site') }}
+                                </a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link" href="{{ route('vendors.index') }}">{{ __('vendor.vendor') }}</a>
+                                <a class="nav-link {{ request()->routeIs('vendors.*') ? 'active' : '' }}"
+                                    href="{{ route('vendors.index') }}">
+                                    {{ __('vendor.vendor') }}
+                                </a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link" href="{{ route('profile.show') }}">{{ __('user.profile') }}</a>
+                                <a class="nav-link {{ request()->routeIs('profile.*') ? 'active' : '' }}"
+                                    href="{{ route('profile.show') }}">
+                                    {{ __('user.profile') }}
+                                </a>
                             </li>
                         @endauth
                     </ul>
 
-                    <!-- Right Side Of Navbar -->
+                    <!-- Right Side -->
                     <ul class="navbar-nav ms-auto">
-                        <!-- Authentication Links -->
                         @guest
                             @if (Route::has('login'))
                                 <li class="nav-item">
-                                    <a class="nav-link" href="{{ route('login') }}">{{ __('Login') }}</a>
+                                    <a class="nav-link {{ request()->routeIs('login') ? 'active' : '' }}"
+                                        href="{{ route('login') }}">
+                                        {{ __('Login') }}
+                                    </a>
                                 </li>
                             @endif
 
                             @if (Route::has('register'))
                                 <li class="nav-item">
-                                    <a class="nav-link" href="{{ route('register') }}">{{ __('Register') }}</a>
+                                    <a class="nav-link {{ request()->routeIs('register') ? 'active' : '' }}"
+                                        href="{{ route('register') }}">
+                                        {{ __('Register') }}
+                                    </a>
                                 </li>
                             @endif
                         @else
                             <li class="nav-item dropdown">
-                                <a id="navbarDropdown" class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" v-pre>
+                                <a id="navbarDropdown" class="nav-link dropdown-toggle" href="#" role="button"
+                                    data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                     {{ Auth::user()->name }}
                                 </a>
 
-                                <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
-                                    <a class="dropdown-item" href="{{ route('logout') }}"
-                                       onclick="event.preventDefault();
-                                                     document.getElementById('logout-form').submit();">
-                                        {{ __('Logout') }}
-                                    </a>
-
-                                    <form id="logout-form" action="{{ route('logout') }}" method="POST" class="d-none">
-                                        @csrf
-                                    </form>
-                                </div>
+                                <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
+                                    <li>
+                                        <a class="dropdown-item" href="{{ route('profile.show') }}">
+                                            {{ __('user.profile') }}
+                                        </a>
+                                    </li>
+                                    <li>
+                                        <hr class="dropdown-divider">
+                                    </li>
+                                    <li>
+                                        <form action="{{ route('logout') }}" method="POST">
+                                            @csrf
+                                            <button type="submit" class="dropdown-item">
+                                                {{ __('Logout') }}
+                                            </button>
+                                        </form>
+                                    </li>
+                                </ul>
                             </li>
                         @endguest
                     </ul>
@@ -88,12 +118,12 @@
         </nav>
 
         <main class="py-4">
-            <div class="container">
-                @yield('content')
-            </div>
+            @yield('content')
         </main>
     </div>
+
     @stack('scripts')
     @livewireScripts
 </body>
+
 </html>

--- a/resources/views/layouts/site.blade.php
+++ b/resources/views/layouts/site.blade.php
@@ -3,128 +3,164 @@
 @section('title', __('site.detail'))
 
 @section('content')
-<div class="row">
-    <div class="col-md-4 order-2 order-md-1">
-        <div class="card">
-            <div class="card-header">
-                <div class="float-end">
-                    {!! FormField::formButton(
-                        ['route' => ['sites.check_now', $site->id]],
-                        __('site.check_now'),
-                        ['class' => 'btn btn-success', 'id' => 'check_now_'.$site->id]
-                    ) !!}
+    <div class="container py-4">
+        <div class="row">
+            {{-- Sidebar info --}}
+            <div class="col-md-4 order-2 order-md-1">
+                <div class="card shadow-sm">
+                    <div class="card-header d-flex align-items-center justify-content-between">
+                        <h4 class="h6 mb-0">{{ __('site.site') }}</h4>
+                        {!! FormField::formButton(['route' => ['sites.check_now', $site->id]], __('site.check_now'), [
+                            'class' => 'btn btn-success',
+                            'id' => 'check_now_' . $site->id,
+                        ]) !!}
+                    </div>
+
+                    <div class="card-body p-0">
+                        <div class="table-responsive">
+                            <table class="table table-sm mb-0 align-middle">
+                                <tbody>
+                                    <tr>
+                                        <th class="w-50 text-muted">{{ __('site.name') }}</th>
+                                        <td>{{ $site->name }}</td>
+                                    </tr>
+                                    <tr>
+                                        <th class="text-muted">{{ __('site.url') }}</th>
+                                        <td><a target="_blank" rel="noopener"
+                                                href="{{ $site->url }}">{{ $site->url }}</a></td>
+                                    </tr>
+                                    <tr>
+                                        <th class="text-muted">{{ __('vendor.vendor') }}</th>
+                                        <td>{{ $site->vendor->name }}</td>
+                                    </tr>
+                                    <tr>
+                                        <th class="text-muted">{{ __('app.status') }}</th>
+                                        <td>{{ $site->is_active ? 'Active' : 'Inactive' }}</td>
+                                    </tr>
+                                    <tr>
+                                        <th class="text-muted">{{ __('site.check_interval') }}</th>
+                                        <td>{{ __('time.every') }} {{ $site->check_interval }}
+                                            {{ trans_choice('time.minutes', $site->check_interval) }}</td>
+                                    </tr>
+                                    <tr>
+                                        <th class="text-muted">{{ __('site.priority_code') }}</th>
+                                        <td>{{ $site->priority_code }}</td>
+                                    </tr>
+                                    <tr>
+                                        <th class="text-muted">{{ __('site.warning_threshold') }}</th>
+                                        <td>{{ $site->warning_threshold }} {{ __('time.miliseconds') }}</td>
+                                    </tr>
+                                    <tr>
+                                        <th class="text-muted">{{ __('site.down_threshold') }}</th>
+                                        <td>{{ $site->down_threshold }} {{ __('time.miliseconds') }}</td>
+                                    </tr>
+                                    <tr>
+                                        <th class="text-muted">{{ __('site.notify_user_interval') }}</th>
+                                        <td>{{ __('time.every') }} {{ $site->notify_user_interval }}
+                                            {{ trans_choice('time.minutes', $site->notify_user_interval) }}</td>
+                                    </tr>
+                                    <tr>
+                                        <th class="text-muted">{{ __('site.last_check_at') }}</th>
+                                        <td>
+                                            {{ $site->last_check_at }} <br>
+                                            {{ optional($site->last_check_at)->diffForHumans() }}
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="text-muted">{{ __('site.last_notify_user_at') }}</th>
+                                        <td>
+                                            {{ $site->last_notify_user_at }} <br>
+                                            {{ optional($site->last_notify_user_at)->diffForHumans() }}
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="text-muted">{{ __('app.created_at') }}</th>
+                                        <td>{{ $site->created_at }}</td>
+                                    </tr>
+                                    <tr>
+                                        <th class="text-muted">{{ __('app.updated_at') }}</th>
+                                        <td>{{ $site->updated_at }}</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+
+                    <div class="card-footer d-flex justify-content-between">
+                        @can('update', $site)
+                            {{ link_to_route('sites.edit', __('site.edit'), [$site], ['class' => 'btn btn-warning', 'id' => 'edit-site-' . $site->id]) }}
+                        @endcan
+                        {{ link_to_route('home', __('app.back_to_dashboard'), [], ['class' => 'btn btn-link']) }}
+                    </div>
                 </div>
-                <h4 class="">{{ __('site.site') }}</h4>
             </div>
-            <div class="card-body">
-                <table class="table table-sm">
-                    <tbody>
-                        <tr><td>{{ __('site.name') }}</td><td>{{ $site->name }}</td></tr>
-                        <tr><td>{{ __('site.url') }}</td><td><a target="_blank" href="{{ $site->url }}">{{ $site->url }}</a></td></tr>
-                        <tr><td>{{ __('vendor.vendor') }}</td><td>{{ $site->vendor->name }}</td></tr>
-                        <tr><td>{{ __('app.status') }}</td><td>{{ $site->is_active }}</td></tr>
-                        <tr>
-                            <td>{{ __('site.check_interval') }}</td>
-                            <td>
-                                {{ __('time.every') }}
-                                {{ $site->check_interval }}
-                                {{ trans_choice('time.minutes', $site->check_interval) }}
-                            </td>
-                        </tr>
-                        <tr><td>{{ __('site.priority_code') }}</td><td>{{ $site->priority_code }}</td></tr>
-                        <tr><td>{{ __('site.warning_threshold') }}</td><td>{{ $site->warning_threshold }} {{ __('time.miliseconds') }}</td></tr>
-                        <tr><td>{{ __('site.down_threshold') }}</td><td>{{ $site->down_threshold }} {{ __('time.miliseconds') }}</td></tr>
-                        <tr>
-                            <td>{{ __('site.notify_user_interval') }}</td>
-                            <td>
-                                {{ __('time.every') }}
-                                {{ $site->notify_user_interval }}
-                                {{ trans_choice('time.minutes', $site->notify_user_interval) }}
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>{{ __('site.last_check_at') }}</td>
-                            <td>
-                                {{ $site->last_check_at }} <br>
-                                {{ optional($site->last_check_at)->diffForHumans() }}
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>{{ __('site.last_notify_user_at') }}</td>
-                            <td>
-                                {{ $site->last_check_at }} <br>
-                                {{ optional($site->last_notify_user_at)->diffForHumans() }}
-                            </td>
-                        </tr>
-                        <tr><td>{{ __('app.created_at') }}</td><td>{{ $site->created_at }}</td></tr>
-                        <tr><td>{{ __('app.updated_at') }}</td><td>{{ $site->updated_at }}</td></tr>
-                    </tbody>
-                </table>
-            </div>
-            <div class="card-footer">
-                @can('update', $site)
-                    {{ link_to_route('sites.edit', __('site.edit'), [$site], ['class' => 'btn btn-warning', 'id' => 'edit-site-'.$site->id]) }}
-                @endcan
-                {{ link_to_route('home', __('app.back_to_dashboard'), [], ['class' => 'btn btn-link']) }}
+
+            {{-- Main content --}}
+            <div class="col-md-8 order-1 order-md-2">
+                <div class="d-md-flex align-items-start justify-content-between flex-wrap gap-2 mb-3">
+                    <div class="btn-group" role="group" aria-label="Time range">
+                        {{ link_to_route(Route::currentRouteName(), '1h', [$site, 'time_range' => '1h'], ['class' => 'btn btn-outline-primary px-2' . ($timeRange == '1h' ? ' active' : '')]) }}
+                        {{ link_to_route(Route::currentRouteName(), '6h', [$site, 'time_range' => '6h'], ['class' => 'btn btn-outline-primary px-2' . ($timeRange == '6h' ? ' active' : '')]) }}
+                        {{ link_to_route(Route::currentRouteName(), '24h', [$site, 'time_range' => '24h'], ['class' => 'btn btn-outline-primary px-2' . ($timeRange == '24h' ? ' active' : '')]) }}
+                        {{ link_to_route(Route::currentRouteName(), '7d', [$site, 'time_range' => '7d'], ['class' => 'btn btn-outline-primary px-2' . ($timeRange == '7d' ? ' active' : '')]) }}
+                        {{ link_to_route(Route::currentRouteName(), '14d', [$site, 'time_range' => '14d'], ['class' => 'btn btn-outline-primary px-2' . ($timeRange == '14d' ? ' active' : '')]) }}
+                        {{ link_to_route(Route::currentRouteName(), '30d', [$site, 'time_range' => '30d'], ['class' => 'btn btn-outline-primary px-2' . ($timeRange == '30d' ? ' active' : '')]) }}
+                        {{ link_to_route(Route::currentRouteName(), '3Mo', [$site, 'time_range' => '3Mo'], ['class' => 'btn btn-outline-primary px-2' . ($timeRange == '3Mo' ? ' active' : '')]) }}
+                        {{ link_to_route(Route::currentRouteName(), '6Mo', [$site, 'time_range' => '6Mo'], ['class' => 'btn btn-outline-primary px-2' . ($timeRange == '6Mo' ? ' active' : '')]) }}
+                    </div>
+
+                    {{ Form::open(['method' => 'get', 'class' => 'row row-cols-lg-auto g-2 align-items-center']) }}
+                    <div class="col">
+                        {{ Form::text('start_time', $startTime->format('Y-m-d H:i'), ['class' => 'date_time_select form-control', 'style' => 'width:150px']) }}
+                    </div>
+                    <div class="col">
+                        {{ Form::text('end_time', $endTime->format('Y-m-d H:i'), ['class' => 'date_time_select form-control', 'style' => 'width:150px']) }}
+                    </div>
+                    <div class="col d-flex gap-2">
+                        {{ Form::submit('View Report', ['class' => 'btn btn-info']) }}
+                        {{ link_to_route('sites.show', __('app.reset'), $site, ['class' => 'btn btn-secondary']) }}
+                    </div>
+                    {{ Form::close() }}
+                </div>
+
+                <ul class="nav nav-tabs mb-3">
+                    <li class="nav-item">
+                        {{ link_to_route('sites.show', __('monitoring_log.graph'), [$site->id] + request(['time_range', 'start_time', 'end_time']), ['class' => 'nav-link ' . (in_array(Request::segment(3), [null]) ? 'active' : '')]) }}
+                    </li>
+                    <li class="nav-item">
+                        {{ link_to_route('sites.timeline', __('monitoring_log.monitoring_log'), [$site->id] + request(['time_range', 'start_time', 'end_time']), ['class' => 'nav-link ' . (in_array(Request::segment(3), ['timeline']) ? 'active' : '')]) }}
+                    </li>
+                </ul>
+
+                @yield('site_content')
             </div>
         </div>
     </div>
-    <div class="col-md-8 order-1 order-md-2">
-        <div class="py-4 py-md-0 clearfix">
-            <div class="btn-group mb-3" role="group">
-                {{ link_to_route(Route::currentRouteName(), '1h', [$site, 'time_range' => '1h'], ['class' => 'px-2 btn btn-outline-primary'.($timeRange == '1h' ? ' active' : '')]) }}
-                {{ link_to_route(Route::currentRouteName(), '6h', [$site, 'time_range' => '6h'], ['class' => 'px-2 btn btn-outline-primary'.($timeRange == '6h' ? ' active' : '')]) }}
-                {{ link_to_route(Route::currentRouteName(), '24h', [$site, 'time_range' => '24h'], ['class' => 'px-2 btn btn-outline-primary'.($timeRange == '24h' ? ' active' : '')]) }}
-                {{ link_to_route(Route::currentRouteName(), '7d', [$site, 'time_range' => '7d'], ['class' => 'px-2 btn btn-outline-primary'.($timeRange == '7d' ? ' active' : '')]) }}
-                {{ link_to_route(Route::currentRouteName(), '14d', [$site, 'time_range' => '14d'], ['class' => 'px-2 btn btn-outline-primary'.($timeRange == '14d' ? ' active' : '')]) }}
-                {{ link_to_route(Route::currentRouteName(), '30d', [$site, 'time_range' => '30d'], ['class' => 'px-2 btn btn-outline-primary'.($timeRange == '30d' ? ' active' : '')]) }}
-                {{ link_to_route(Route::currentRouteName(), '3Mo', [$site, 'time_range' => '3Mo'], ['class' => 'px-2 btn btn-outline-primary'.($timeRange == '3Mo' ? ' active' : '')]) }}
-                {{ link_to_route(Route::currentRouteName(), '6Mo', [$site, 'time_range' => '6Mo'], ['class' => 'px-2 btn btn-outline-primary'.($timeRange == '6Mo' ? ' active' : '')]) }}
-            </div>
-            <div class="float-end">
-                {{ Form::open(['method' => 'get', 'class' => 'row row-cols-lg-auto g-2 align-items-center']) }}
-                <div class="col">
-                    {{ Form::text('start_time', $startTime->format('Y-m-d H:i'), ['class' => 'date_time_select form-control', 'style' => 'width:150px']) }}
-                </div>
-                <div class="col">
-                    {{ Form::text('end_time', $endTime->format('Y-m-d H:i'), ['class' => 'date_time_select form-control', 'style' => 'width:150px']) }}
-                </div>
-                <div class="col">
-                    {{ Form::submit('View Report', ['class' => 'btn btn-info mr-1']) }}
-                    {{ link_to_route('sites.show', __('app.reset'), $site, ['class' => 'btn btn-secondary']) }}
-                </div>
-                {{ Form::close() }}
-            </div>
-        </div>
-
-        <ul class="nav nav-tabs">
-            <li class="nav-item">
-                {{ link_to_route('sites.show', __('monitoring_log.graph'), [$site->id]+request(['time_range', 'start_time', 'end_time']), ['class' => 'nav-link '.(in_array(Request::segment(3), [null]) ? 'active' : '')]) }}
-            </li>
-            <li class="nav-item">
-                {{ link_to_route('sites.timeline', __('monitoring_log.monitoring_log'), [$site->id]+request(['time_range', 'start_time', 'end_time']), ['class' => 'nav-link '.(in_array(Request::segment(3), ['timeline']) ? 'active' : '')]) }}
-            </li>
-        </ul>
-
-        @yield('site_content')
-    </div>
-</div>
-<br>
+    <br>
 @endsection
 
 @push('styles')
-<link rel="stylesheet" href="{{ url('css/plugins/jquery.datetimepicker.css') }}">
+    <link rel="stylesheet"
+        href="https://cdnjs.cloudflare.com/ajax/libs/jquery-datetimepicker/2.5.20/jquery.datetimepicker.min.css"
+        integrity="sha512-f0tzWhCwVFS3WeYaofoLWkTP62ObhewQ1EZn65oSYDZUg1+CyywGKkWzm8BxaJj5HGKI72PnMH9jYyIFz+GH7g=="
+        crossorigin="anonymous" referrerpolicy="no-referrer" />
 @endpush
 
 @push('scripts')
-<script src="{{ url('js/jquery.min.js') }}"></script>
-<script src="{{ url('js/plugins/jquery.datetimepicker.js') }}"></script>
-<script>
-    $('.date_time_select').datetimepicker({
-        format:'Y-m-d H:i',
-        closeOnTimeSelect: true,
-        scrollInput: false,
-        dayOfWeekStart: 1
-    });
-</script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"
+        integrity="sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="
+        crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-datetimepicker/2.5.20/jquery.datetimepicker.min.js"
+        integrity="sha512-L7jgg7T9UbYc7hXogUKssqe1B5MsgrcviNxsRbO53dDSiw/JxuA/4kVQvEORmZJ6Re3fVF3byN5TT7czo9Rdug=="
+        crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            $('.date_time_select').datetimepicker({
+                format: 'Y-m-d H:i',
+                closeOnTimeSelect: true,
+                scrollInput: false,
+                dayOfWeekStart: 1
+            });
+        });
+    </script>
 @endpush

--- a/resources/views/livewire/uptime_badge.blade.php
+++ b/resources/views/livewire/uptime_badge.blade.php
@@ -1,7 +1,6 @@
 <div {{ $uptimePollState }}>
     @foreach ($this->getSiteMonitoringLogs($site) as $monitoringLog)
-        <span
-            class="badge bg-{{ $monitoringLog->uptime_badge_bg_color }} log_indicator"
+        <span class="badge bg-{{ $monitoringLog->uptime_badge_bg_color }} log_indicator"
             title="{{ $monitoringLog->uptime_badge_title }}">&nbsp;</span>
     @endforeach
 </div>

--- a/resources/views/monitoring/index.blade.php
+++ b/resources/views/monitoring/index.blade.php
@@ -1,73 +1,90 @@
 @extends('layouts.app')
 
 @section('content')
-
-<div class="row">
-    <div class="col-md-6">
-        <h1>
-            Dashboard
-            @if (request('uptime_poll', 0))
-                <a href="{{ route('home', ['uptime_poll' => 0] + Request::except(['uptime_poll'])) }}" class="btn btn-danger">STOP Monitoring</a>
-            @else
-                <a href="{{ route('home', ['uptime_poll' => 1] + Request::except(['uptime_poll'])) }}" class="btn btn-info">START Monitoring</a>
-            @endif
-        </h1>
-    </div>
-    <div class="col-md-6">
-        <div class="float-end">
-            {{ Form::open(['method' => 'get', 'class' => 'row row-cols-lg-auto g-2 align-items-center']) }}
-            <div class="col-6">
-                {!! Form::text('q', request('q'), ['placeholder' => __('app.search'), 'style' => 'width:160px']) !!}
+    <div class="container py-4">
+        <div class="row align-items-center mb-3">
+            <div class="col-md-6 d-flex flex-wrap align-items-center gap-2">
+                <h1 class="h3 mb-0">Dashboard</h1>
+                @if (request('uptime_poll', 0))
+                    <a href="{{ route('home', ['uptime_poll' => 0] + Request::except(['uptime_poll'])) }}"
+                        class="btn btn-danger    -sm">STOP Monitoring</a>
+                @else
+                    <a href="{{ route('home', ['uptime_poll' => 1] + Request::except(['uptime_poll'])) }}"
+                        class="btn btn-info btn-sm">START Monitoring</a>
+                @endif
             </div>
-            <div class="col-6">
-                {!! Form::select('vendor_id', $availableVendors, request('vendor_id'), ['placeholder' => __('vendor.all')]) !!}
-            </div>
-            <div class="col-12">
-                {{ Form::hidden('uptime_poll', request('uptime_poll', 0)) }}
-                {{ Form::submit(__('app.search')) }}
-                {{ link_to_route('home', __('app.reset'), Request::only(['uptime_poll']), ['class' => 'btn btn-link']) }}
-            </div>
-            {{ Form::close() }}
-        </div>
-    </div>
-</div>
-<br>
-<div class="row mb-4">
-    @foreach ($sites as $site)
-        <a href="{{ route('sites.show', [$site]) }}" class="col-md-6 col-lg-4 col-xl-3 px-1 mb-2 text-decoration-none">
-            <div class="card">
-                <div class="card-body py-2 px-3">
-                    <div class="row">
-                        <div class="col-6 px-1">
-                            {{ $site->name }}<br>
-                            <span class="badge bg-secondary">{{ $site->vendor->name }}</span>
-                        </div>
-                        <div class="col-6 px-1 text-end">
-                            <div class="small" title="{{ __('sites.check_interval') }}: {{ __('time.every') }} {{ $site->check_interval }} {{ trans_choice('time.minutes', $site->check_interval) }}">
-                                {{ $site->check_interval }} {{ trans_choice('time.minutes', $site->check_interval) }}
-                            </div>
-                            @livewire('uptime-badge', [
-                                'site' => $site,
-                                'uptimePoll' => request('uptime_poll', 0)
-                            ])
-                        </div>
+            <div class="col-md-6">
+                <div class="d-flex justify-content-md-end">
+                    {{ Form::open(['method' => 'get', 'class' => 'row row-cols-lg-auto g-2 align-items-center']) }}
+                    <div class="col">
+                        {!! Form::text('q', request('q'), [
+                            'placeholder' => __('app.search'),
+                            'class' => 'form-control',
+                            'style' => 'width:160px',
+                        ]) !!}
                     </div>
+                    <div class="col">
+                        {!! Form::select('vendor_id', $availableVendors, request('vendor_id'), [
+                            'placeholder' => __('vendor.all'),
+                            'class' => 'form-select',
+                        ]) !!}
+                    </div>
+                    <div class="col d-flex gap-2">
+                        {{ Form::hidden('uptime_poll', request('uptime_poll', 0)) }}
+                        {{ Form::submit(__('app.search'), ['class' => 'btn btn-primary']) }}
+                        {{ link_to_route('home', __('app.reset'), Request::only(['uptime_poll']), ['class' => 'btn btn-secondary']) }}
+                    </div>
+                    {{ Form::close() }}
                 </div>
             </div>
-        </a>
-    @endforeach
-</div>
+        </div>
+
+        <div class="row g-2 mb-4">
+            @foreach ($sites as $site)
+                <div class="col-md-6 col-lg-4 col-xl-3">
+                    <a href="{{ route('sites.show', [$site]) }}" class="text-decoration-none d-block h-100">
+                        <div class="card shadow-sm h-100 card-hover">
+                            <div class="card-body py-2 px-3">
+                                <div class="row">
+                                    <div class="col-6 px-1">
+                                        <div class="fw-semibold text-body">{{ $site->name }}</div>
+                                        <span class="badge bg-secondary">{{ $site->vendor->name }}</span>
+                                    </div>
+                                    <div class="col-6 px-1 text-end">
+                                        <div class="small"
+                                            title="{{ __('site.check_interval') }}: {{ __('time.every') }} {{ $site->check_interval }} {{ trans_choice('time.minutes', $site->check_interval) }}">
+                                            {{ $site->check_interval }}
+                                            {{ trans_choice('time.minutes', $site->check_interval) }}
+                                        </div>
+                                        @livewire('uptime-badge', [
+                                            'site' => $site,
+                                            'uptimePoll' => request('uptime_poll', 0),
+                                        ])
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+            @endforeach
+        </div>
+    </div>
 @endsection
 
 @push('styles')
-<style>
-    .log_indicator {
-        padding: 4px 1px;
-        cursor: pointer;
-        margin-left: -0.4px;
-    }
-    .card:hover {
-        transform: scale(1.02);
-    }
-</style>
+    <style>
+        .log_indicator {
+            padding: 4px 1px;
+            cursor: pointer;
+            margin-left: -0.4px;
+        }
+
+        .card-hover {
+            transition: transform .15s ease-in-out;
+        }
+
+        .card-hover:hover {
+            transform: scale(1.02);
+        }
+    </style>
 @endpush

--- a/resources/views/sites/create.blade.php
+++ b/resources/views/sites/create.blade.php
@@ -3,28 +3,45 @@
 @section('title', __('site.create'))
 
 @section('content')
-<div class="row justify-content-center">
-    <div class="col-md-6">
-        <div class="card">
-            <div class="card-header">{{ __('site.create') }}</div>
-            {{ Form::open(['route' => 'sites.store']) }}
-            <div class="card-body">
-                <div class="row">
-                    <div class="col-md-8">
-                        {!! FormField::text('name', ['required' => true, 'label' => __('site.name'), 'placeholder' => 'Example Web']) !!}
+    <div class="container py-4">
+        <div class="row justify-content-center">
+            <div class="col-md-6">
+                <div class="card shadow-sm">
+                    <div class="card-header">{{ __('site.create') }}</div>
+
+                    {{ Form::open(['route' => 'sites.store']) }}
+                    <div class="card-body">
+                        <div class="row g-3">
+                            <div class="col-md-8">
+                                {!! FormField::text('name', [
+                                    'required' => true,
+                                    'label' => __('site.name'),
+                                    'placeholder' => 'Example Web',
+                                ]) !!}
+                            </div>
+                            <div class="col-md-4">
+                                {!! FormField::select('vendor_id', $availableVendors, [
+                                    'label' => __('vendor.vendor'),
+                                    'placeholder' => __('vendor.all'),
+                                    'class' => 'form-select', // pastikan select tampil ala BS5
+                                ]) !!}
+                            </div>
+                            <div class="col-12">
+                                {!! FormField::text('url', [
+                                    'label' => __('site.url'),
+                                    'placeholder' => 'https://example.net',
+                                ]) !!}
+                            </div>
+                        </div>
                     </div>
-                    <div class="col-md-4">
-                        {!! FormField::select('vendor_id', $availableVendors, ['label' => __('vendor.vendor')]) !!}
+
+                    <div class="card-footer d-flex justify-content-end gap-2">
+                        {{ Form::submit(__('app.create'), ['class' => 'btn btn-success']) }}
+                        {{ link_to_route('sites.index', __('app.cancel'), [], ['class' => 'btn btn-link']) }}
                     </div>
+                    {{ Form::close() }}
                 </div>
-                {!! FormField::text('url', ['label' => __('site.url'), 'placeholder' => 'https://example.net']) !!}
             </div>
-            <div class="card-footer">
-                {{ Form::submit(__('app.create'), ['class' => 'btn btn-success']) }}
-                {{ link_to_route('sites.index', __('app.cancel'), [], ['class' => 'btn btn-link']) }}
-            </div>
-            {{ Form::close() }}
         </div>
     </div>
-</div>
 @endsection

--- a/resources/views/sites/edit.blade.php
+++ b/resources/views/sites/edit.blade.php
@@ -3,111 +3,140 @@
 @section('title', __('site.edit'))
 
 @section('content')
-<div class="row justify-content-center">
-    <div class="col-md-6">
-        @if (request('action') == 'delete' && $site)
-        @can('delete', $site)
-            <div class="card">
-                <div class="card-header">{{ __('site.delete') }}</div>
-                <div class="card-body">
-                    <label class="control-label text-primary">{{ __('site.name') }}</label>
-                    <p>{{ $site->name }}</p>
-                    <label class="control-label text-primary">{{ __('site.url') }}</label>
-                    <p>{{ $site->url }}</p>
-                    <label class="control-label text-primary">{{ __('app.status') }}</label>
-                    <p>{{ $site->is_active }}</p>
-                    {!! $errors->first('site_id', '<span class="form-error small">:message</span>') !!}
-                </div>
-                <hr style="margin:0">
-                <div class="card-body text-danger">{{ __('site.delete_confirm') }}</div>
-                <div class="card-footer">
-                    {!! FormField::delete(
-                        ['route' => ['sites.destroy', $site]],
-                        __('app.delete_confirm_button'),
-                        ['class' => 'btn btn-danger'],
-                        ['site_id' => $site->id]
-                    ) !!}
-                    {{ link_to_route('sites.edit', __('app.cancel'), [$site], ['class' => 'btn btn-link']) }}
-                </div>
+    <div class="container py-4">
+        <div class="row justify-content-center">
+            <div class="col-md-6">
+
+                @if (request('action') == 'delete' && $site)
+                    @can('delete', $site)
+                        <div class="card shadow-sm">
+                            <div class="card-header">{{ __('site.delete') }}</div>
+
+                            <div class="card-body">
+                                <div class="mb-3">
+                                    <label class="form-label text-primary">{{ __('site.name') }}</label>
+                                    <p class="mb-0">{{ $site->name }}</p>
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label text-primary">{{ __('site.url') }}</label>
+                                    <p class="mb-0">{{ $site->url }}</p>
+                                </div>
+                                <div class="mb-0">
+                                    <label class="form-label text-primary">{{ __('app.status') }}</label>
+                                    <p class="mb-0">{{ $site->is_active ? 'Active' : 'Inactive' }}</p>
+                                </div>
+
+                                @if ($errors->has('site_id'))
+                                    <div class="small text-danger mt-2">{{ $errors->first('site_id') }}</div>
+                                @endif
+                            </div>
+
+                            <div class="card-body text-danger border-top">
+                                {{ __('site.delete_confirm') }}
+                            </div>
+
+                            <div class="card-footer d-flex justify-content-between">
+                                {!! FormField::delete(
+                                    ['route' => ['sites.destroy', $site]],
+                                    __('app.delete_confirm_button'),
+                                    ['class' => 'btn btn-danger'],
+                                    ['site_id' => $site->id],
+                                ) !!}
+                                {{ link_to_route('sites.edit', __('app.cancel'), [$site], ['class' => 'btn btn-link']) }}
+                            </div>
+                        </div>
+                    @endcan
+                @else
+                    <div class="card shadow-sm">
+                        <div class="card-header">{{ __('site.edit') }}</div>
+
+                        {{ Form::model($site, ['route' => ['sites.update', $site], 'method' => 'patch']) }}
+                        <div class="card-body">
+                            <div class="row g-3">
+                                <div class="col-md-8">
+                                    {!! FormField::text('name', ['required' => true, 'label' => __('site.name')]) !!}
+                                </div>
+                                <div class="col-md-4">
+                                    {!! FormField::select('vendor_id', $availableVendors, [
+                                        'label' => __('vendor.vendor'),
+                                        'class' => 'form-select', // BS5 select
+                                    ]) !!}
+                                </div>
+
+                                <div class="col-12">
+                                    {!! FormField::text('url', ['label' => __('site.url')]) !!}
+                                </div>
+
+                                <div class="col-md-5">
+                                    {!! FormField::text('check_interval', [
+                                        'label' => __('site.check_interval'),
+                                        'addon' => ['before' => __('time.every'), 'after' => trans_choice('time.minutes', $site->check_interval)],
+                                        'type' => 'number',
+                                        'min' => 1,
+                                        'max' => 60,
+                                    ]) !!}
+                                </div>
+                                <div class="col-md-7">
+                                    {!! FormField::radios(
+                                        'priority_code',
+                                        ['high' => 'High', 'normal' => 'Normal', 'low' => 'Low'],
+                                        ['label' => __('site.priority_code')],
+                                    ) !!}
+                                </div>
+
+                                <div class="col-md-6">
+                                    {!! FormField::text('warning_threshold', [
+                                        'label' => __('site.warning_threshold'),
+                                        'addon' => ['after' => __('time.miliseconds')],
+                                        'type' => 'number',
+                                        'min' => 1000,
+                                        'max' => 30000,
+                                        'step' => 1000,
+                                    ]) !!}
+                                </div>
+                                <div class="col-md-6">
+                                    {!! FormField::text('down_threshold', [
+                                        'label' => __('site.down_threshold'),
+                                        'addon' => ['after' => __('time.miliseconds')],
+                                        'type' => 'number',
+                                        'min' => 2000,
+                                        'max' => 60000,
+                                        'step' => 1000,
+                                    ]) !!}
+                                </div>
+
+                                <div class="col-md-6">
+                                    {!! FormField::text('notify_user_interval', [
+                                        'label' => __('site.notify_user_interval'),
+                                        'addon' => ['before' => __('time.every'), 'after' => trans_choice('time.minutes', $site->notify_user_interval)],
+                                        'type' => 'number',
+                                        'min' => 0,
+                                        'max' => 60,
+                                        'info' => ['text' => __('site.notify_user_interval_form_info'), 'class' => 'primary'],
+                                    ]) !!}
+                                </div>
+                                <div class="col-md-6">
+                                    {!! FormField::radios(
+                                        'is_active',
+                                        [1 => __('app.active'), 0 => __('app.inactive')],
+                                        ['label' => __('app.status')],
+                                    ) !!}
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="card-footer d-flex align-items-center gap-2">
+                            {{ Form::submit(__('site.update'), ['class' => 'btn btn-warning']) }}
+                            {{ link_to_route('sites.show', __('app.cancel'), [$site], ['class' => 'btn btn-link']) }}
+                            @can('delete', $site)
+                                {{ link_to_route('sites.edit', __('app.delete'), [$site, 'action' => 'delete'], ['class' => 'btn btn-danger ms-auto', 'id' => 'del-site-' . $site->id]) }}
+                            @endcan
+                        </div>
+                        {{ Form::close() }}
+                    </div>
+                @endif
+
             </div>
-        @endcan
-        @else
-        <div class="card">
-            <div class="card-header">{{ __('site.edit') }}</div>
-            {{ Form::model($site, ['route' => ['sites.update', $site], 'method' => 'patch']) }}
-            <div class="card-body">
-                <div class="row">
-                    <div class="col-md-8">
-                        {!! FormField::text('name', ['required' => true, 'label' => __('site.name')]) !!}
-                    </div>
-                    <div class="col-md-4">
-                        {!! FormField::select('vendor_id', $availableVendors, ['label' => __('vendor.vendor')]) !!}
-                    </div>
-                </div>
-                {!! FormField::text('url', ['label' => __('site.url')]) !!}
-                <div class="row">
-                    <div class="col-md-5">
-                        {!! FormField::text('check_interval', [
-                            'label' => __('site.check_interval'),
-                            'addon' => ['before' => __('time.every'), 'after' => trans_choice('time.minutes', $site->check_interval)],
-                            'type' => 'number',
-                            'min' => 1,
-                            'max' => 60,
-                        ]) !!}
-                    </div>
-                    <div class="col-md-7">{!! FormField::radios('priority_code', ['high' => 'High', 'normal' => 'Normal', 'low' => 'Low'], ['label' => __('site.priority_code')]) !!}</div>
-                </div>
-                <div class="row">
-                    <div class="col-6">
-                        {!! FormField::text('warning_threshold', [
-                            'label' => __('site.warning_threshold'),
-                            'addon' => ['after' => __('time.miliseconds')],
-                            'type' => 'number',
-                            'min' => 1000,
-                            'max' => 30000,
-                            'step' => 1000,
-                        ]) !!}
-                    </div>
-                    <div class="col-6">
-                        {!! FormField::text('down_threshold', [
-                            'label' => __('site.down_threshold'),
-                            'addon' => ['after' => __('time.miliseconds')],
-                            'type' => 'number',
-                            'min' => 2000,
-                            'max' => 60000,
-                            'step' => 1000,
-                        ]) !!}
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-6">
-                        {!! FormField::text('notify_user_interval', [
-                            'label' => __('site.notify_user_interval'),
-                            'addon' => ['before' => __('time.every'), 'after' => trans_choice('time.minutes', $site->notify_user_interval)],
-                            'type' => 'number',
-                            'min' => 0,
-                            'max' => 60,
-                            'info' => ['text' => __('site.notify_user_interval_form_info'), 'class' => 'primary'],
-                        ]) !!}
-                    </div>
-                    <div class="col-6">
-                        {!! FormField::radios('is_active', [
-                            1 => __('app.active'),
-                            0 => __('app.inactive'),
-                        ], ['label' => __('app.status')]) !!}
-                    </div>
-                </div>
-            </div>
-            <div class="card-footer">
-                {{ Form::submit(__('site.update'), ['class' => 'btn btn-warning']) }}
-                {{ link_to_route('sites.show', __('app.cancel'), [$site], ['class' => 'btn btn-link']) }}
-                @can('delete', $site)
-                    {{ link_to_route('sites.edit', __('app.delete'), [$site, 'action' => 'delete'], ['class' => 'btn btn-danger float-end', 'id' => 'del-site-'.$site->id]) }}
-                @endcan
-            </div>
-            {{ Form::close() }}
         </div>
     </div>
-</div>
-@endif
 @endsection

--- a/resources/views/sites/index.blade.php
+++ b/resources/views/sites/index.blade.php
@@ -3,70 +3,82 @@
 @section('title', __('site.list'))
 
 @section('content')
-<div class="mb-3">
-    <div class="float-end">
-        @can('create', new App\Models\Site)
-            {{ link_to_route('sites.create', __('site.create'), [], ['class' => 'btn btn-success']) }}
-        @endcan
-    </div>
-    <h2 class="page-title">{{ __('site.list') }} <small>{{ __('app.total') }} : {{ $sites->total() }} {{ __('site.site') }}</small></h2>
-</div>
+    <div class="container py-4">
+        <div class="d-flex align-items-center justify-content-between flex-wrap gap-2 mb-3">
+            <h2 class="h4 mb-0">
+                {{ __('site.list') }}
+                <small class="text-muted">
+                    {{ __('app.total') }} : {{ $sites->total() }} {{ __('site.site') }}
+                </small>
+            </h2>
 
-<div class="row">
-    <div class="col-md-12">
-        <div class="card">
+            @can('create', new App\Models\Site())
+                {{ link_to_route('sites.create', __('site.create'), [], ['class' => 'btn btn-success']) }}
+            @endcan
+        </div>
+
+        <div class="card shadow-sm">
             <div class="card-header">
                 {{ Form::open(['method' => 'get', 'class' => 'row row-cols-lg-auto g-2 align-items-center']) }}
                 <div class="col-12">
-                    {!! Form::text('q', request('q'), ['placeholder' => __('site.search')]) !!}
+                    {!! Form::text('q', request('q'), [
+                        'placeholder' => __('site.search'),
+                        'class' => 'form-control',
+                    ]) !!}
                 </div>
                 <div class="col-12">
-                    {!! Form::select('vendor_id', $availableVendors, request('vendor_id'), ['placeholder' => '--'.__('vendor.all').'--']) !!}
+                    {!! Form::select('vendor_id', $availableVendors, request('vendor_id'), [
+                        'placeholder' => '--' . __('vendor.all') . '--',
+                        'class' => 'form-select',
+                    ]) !!}
                 </div>
-                <div class="col-12">
-                    {{ Form::submit(__('app.search'), ['class' => 'btn btn-secondary btn-sm']) }}
-                    {{ link_to_route('sites.index', __('app.reset'), [], ['class' => 'btn btn-link']) }}
+                <div class="col-12 d-flex gap-2">
+                    {{ Form::submit(__('app.search'), ['class' => 'btn btn-primary btn-sm']) }}
+                    {{ link_to_route('sites.index', __('app.reset'), [], ['class' => 'btn btn-secondary btn-sm']) }}
                 </div>
                 {{ Form::close() }}
             </div>
-            <table class="table table-sm table-responsive-sm table-hover">
-                <thead>
-                    <tr>
-                        <th class="text-center">{{ __('app.table_no') }}</th>
-                        <th>{{ __('site.name') }}</th>
-                        <th>{{ __('site.url') }}</th>
-                        <th>{{ __('vendor.vendor') }}</th>
-                        <th class="text-center">{{ __('app.status') }}</th>
-                        <th class="text-center">{{ __('app.action') }}</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    @foreach($sites as $key => $site)
-                    <tr>
-                        <td class="text-center">{{ $sites->firstItem() + $key }}</td>
-                        <td>{{ $site->name }}</td>
-                        <td><a target="_blank" href="{{ $site->url }}">{{ $site->url }}</a></td>
-                        <td>{{ $site->vendor->name }}</td>
-                        <td class="text-center">{{ $site->is_active }}</td>
-                        <td class="text-center">
-                            @can('view', $site)
-                                {{ link_to_route(
-                                    'sites.show',
-                                    __('app.show'),
-                                    [$site],
-                                    ['id' => 'show-site-' . $site->id]
-                                ) }}
-                            @endcan
-                            @can('update', $site)
-                                | {{ link_to_route('sites.edit', __('app.edit'), [$site], ['id' => 'edit-site-'.$site->id]) }}
-                            @endcan
-                        </td>
-                    </tr>
-                    @endforeach
-                </tbody>
-            </table>
-            <div class="card-body">{{ $sites->appends(Request::except('page'))->render() }}</div>
+
+            <div class="table-responsive">
+                <table class="table table-sm table-hover align-middle mb-0">
+                    <thead>
+                        <tr>
+                            <th class="text-center" style="width:72px">{{ __('app.table_no') }}</th>
+                            <th>{{ __('site.name') }}</th>
+                            <th>{{ __('site.url') }}</th>
+                            <th>{{ __('vendor.vendor') }}</th>
+                            <th class="text-center">{{ __('app.status') }}</th>
+                            <th class="text-center" style="width:160px">{{ __('app.action') }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach ($sites as $key => $site)
+                            <tr>
+                                <td class="text-center">{{ $sites->firstItem() + $key }}</td>
+                                <td>{{ $site->name }}</td>
+                                <td>
+                                    <a target="_blank" rel="noopener" href="{{ $site->url }}">{{ $site->url }}</a>
+                                </td>
+                                <td>{{ $site->vendor->name }}</td>
+                                <td class="text-center">{{ $site->is_active ? 'Active' : 'Inactive' }}</td>
+                                <td class="text-center">
+                                    @can('view', $site)
+                                        {{ link_to_route('sites.show', __('app.show'), [$site], ['id' => 'show-site-' . $site->id]) }}
+                                    @endcan
+                                    @can('update', $site)
+                                        <span class="mx-1 text-muted">|</span>
+                                        {{ link_to_route('sites.edit', __('app.edit'), [$site], ['id' => 'edit-site-' . $site->id]) }}
+                                    @endcan
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="card-body">
+                {{ $sites->appends(Request::except('page'))->render() }}
+            </div>
         </div>
     </div>
-</div>
 @endsection

--- a/resources/views/sites/show.blade.php
+++ b/resources/views/sites/show.blade.php
@@ -1,85 +1,143 @@
 @extends('layouts.site')
 
 @section('site_content')
-<div class="pt-0">
-    <div id="chart_timeline_{{ $site->id }}"></div>
-</div>
+    <div class="pt-0">
+        <div id="chart_timeline_{{ $site->id }}" class="w-100"></div>
+    </div>
 @endsection
-
+@push('styles')
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/apexcharts/5.3.4/apexcharts.min.css"
+        integrity="sha512-IqtQ7LKr3He47p7HjxynmqZfN07VljNkdGyGDdDJ//f1r6bT0IEKQf2CCtSgun/pvbFlNnPDMRrMSQhmSxmSSg=="
+        crossorigin="anonymous" referrerpolicy="no-referrer" />
+@endpush
 @push('scripts')
-<script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
-<script>
-    var options = {
-        series: [{
-            name: 'Response time (ms)',
-            data: {!! json_encode($chartData) !!},
-        }],
-        chart: {
-            id: 'line-datetime',
-            type: 'line',
-            height: 400,
-            zoom: {
-                autoScaleYaxis: true
-            }
-        },
-        annotations: {
-            yaxis: [{
-                y: {{ $site->warning_threshold }},
-                borderColor: 'orange',
-                label: {
-                    show: true,
-                    text: 'Threshold',
-                    style: {
-                        color: "#fff",
-                        background: 'orange'
-                    }
-                }
-            }, {
-                y: {{ $site->down_threshold }},
-                borderColor: 'red',
-                label: {
-                    show: true,
-                    text: 'Down',
-                    style: {
-                        color: "#fff",
-                        background: 'red'
-                    }
-                }
-            }]
-        },
-        dataLabels: {
-            enabled: false
-        },
-        xaxis: {
-            type: 'datetime',
-            min: new Date("{{ $startTime->format('Y-m-d H:i:s') }}").getTime(),
-            max: new Date("{{ $endTime->format('Y-m-d H:i:s') }}").getTime(),
-            labels: {
-                datetimeUTC: false,
-            },
-            title: {
-                text: 'Datetime',
-            },
-        },
-        yaxis: {
-            tickAmount: {{ $site->y_axis_tick_amount }},
-            title: {
-                text: 'Miliseconds',
-            },
-            max: {{ $site->y_axis_max }},
-            min: 0,
-        },
-        stroke: {
-          width: [2]
-        },
-        tooltip: {
-            x: {
-                format: 'dd MMM HH:mm:ss'
-            }
-        },
-    };
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/apexcharts/5.3.4/apexcharts.min.js"
+        integrity="sha512-FImCCel/NA+iTEiLnRklD7hTPfcNdVEwO9niFnKmL/KoSknriTDREY7zdTTgQId1qjbcIEavsyXUlyljCql5cg=="
+        crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script>
+        (function() {
+            // Data & rentang waktu
+            const seriesData = {!! json_encode($chartData) !!};
+            const startMs = {{ $startTime->timestamp * 1000 }};
+            const endMs = {{ $endTime->timestamp * 1000 }};
 
-    var chart = new ApexCharts(document.querySelector("#chart_timeline_{{ $site->id }}"), options);
-    chart.render();
-</script>
+            // Ambil warna dari Bootstrap 5 (fallback jika var tidak tersedia)
+            const css = getComputedStyle(document.documentElement);
+            const clrPrimary = css.getPropertyValue('--bs-primary').trim() || '#0d6efd';
+            const clrWarning = css.getPropertyValue('--bs-warning').trim() || 'orange';
+            const clrDanger = css.getPropertyValue('--bs-danger').trim() || 'red';
+            const clrGrid = css.getPropertyValue('--bs-border-color-translucent').trim() || '#e9ecef';
+
+            const options = {
+                series: [{
+                    name: 'Response time (ms)',
+                    data: seriesData, // format: [[tsMs, value], ...] atau {x: tsMs, y: val}
+                }],
+                chart: {
+                    id: 'line-datetime',
+                    type: 'line',
+                    height: 400,
+                    animations: {
+                        enabled: true
+                    },
+                    toolbar: {
+                        show: true
+                    },
+                    zoom: {
+                        autoScaleYaxis: true
+                    }
+                },
+                colors: [clrPrimary],
+                stroke: {
+                    width: 2,
+                    curve: 'smooth'
+                },
+                markers: {
+                    size: 0
+                },
+                grid: {
+                    borderColor: clrGrid,
+                    strokeDashArray: 3
+                },
+                annotations: {
+                    yaxis: [{
+                            y: {{ $site->warning_threshold }},
+                            borderColor: clrWarning,
+                            label: {
+                                show: true,
+                                text: 'Threshold',
+                                style: {
+                                    color: '#fff',
+                                    background: clrWarning
+                                }
+                            }
+                        },
+                        {
+                            y: {{ $site->down_threshold }},
+                            borderColor: clrDanger,
+                            label: {
+                                show: true,
+                                text: 'Down',
+                                style: {
+                                    color: '#fff',
+                                    background: clrDanger
+                                }
+                            }
+                        }
+                    ]
+                },
+                dataLabels: {
+                    enabled: false
+                },
+                xaxis: {
+                    type: 'datetime',
+                    min: startMs,
+                    max: endMs,
+                    labels: {
+                        datetimeUTC: false
+                    },
+                    title: {
+                        text: 'Datetime'
+                    }
+                },
+                yaxis: {
+                    tickAmount: {{ $site->y_axis_tick_amount }},
+                    title: {
+                        text: 'Milliseconds'
+                    },
+                    max: {{ $site->y_axis_max }},
+                    min: 0,
+                    labels: {
+                        formatter: (val) => Number(val).toLocaleString()
+                    }
+                },
+                tooltip: {
+                    shared: false,
+                    x: {
+                        format: 'dd MMM HH:mm:ss'
+                    },
+                    y: {
+                        formatter: (val) => `${Number(val).toLocaleString()} ms`
+                    }
+                },
+                noData: {
+                    text: 'No data',
+                    align: 'center',
+                    verticalAlign: 'middle'
+                },
+                responsive: [{
+                    breakpoint: 576,
+                    options: {
+                        chart: {
+                            height: 280
+                        }
+                    }
+                }]
+            };
+
+            const el = document.querySelector("#chart_timeline_{{ $site->id }}");
+            const chart = new ApexCharts(el, options);
+            chart.render();
+        })();
+    </script>
 @endpush

--- a/resources/views/sites/timeline.blade.php
+++ b/resources/views/sites/timeline.blade.php
@@ -1,29 +1,56 @@
 @extends('layouts.site')
 
 @section('site_content')
-<div class="pt-2">
-    <table class="table table-sm">
-        <thead>
-            <tr>
-                <th class="text-center">{{ __('app.table_no') }}</th>
-                <th class="col-3">{{ __('app.created_at') }}</th>
-                <th class="col-2 text-center">{{ __('monitoring_log.status_code') }}</th>
-                <th class="col-2 text-end">{{ __('monitoring_log.response_time') }}</th>
-                <th class="col-5">{{ __('monitoring_log.response_message') }}</th>
-            </tr>
-        </thead>
-        <tbody>
-            @foreach ($monitoringLogs as $key => $monitoringLog)
-            <tr>
-                <td class="text-center">{{ $monitoringLogs->firstItem() + $key }}</td>
-                <td>{{ $monitoringLog->created_at }}</td>
-                <td class="text-center">{{ $monitoringLog->status_code }}</td>
-                <td class="text-end">{{ number_format($monitoringLog->response_time, 0) }} {{ __('time.miliseconds') }}</td>
-                <td>{{ $monitoringLog->response_message }}</td>
-            </tr>
-            @endforeach
-        </tbody>
-    </table>
-    {{ $monitoringLogs->appends(Request::except('page'))->links() }}
-</div>
+    <div class="pt-2">
+        <div class="table-responsive">
+            <table class="table table-sm table-hover align-middle mb-0">
+                <thead>
+                    <tr>
+                        <th class="text-center" style="width:72px">{{ __('app.table_no') }}</th>
+                        <th class="text-nowrap" style="width:20%">{{ __('app.created_at') }}</th>
+                        <th class="text-center" style="width:12%">{{ __('monitoring_log.status_code') }}</th>
+                        <th class="text-end" style="width:15%">{{ __('monitoring_log.response_time') }}</th>
+                        <th>{{ __('monitoring_log.response_message') }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($monitoringLogs as $key => $monitoringLog)
+                        @php
+                            $code = (int) $monitoringLog->status_code;
+                            $badge =
+                                $code >= 500
+                                    ? 'danger'
+                                    : ($code >= 400
+                                        ? 'warning'
+                                        : ($code >= 300
+                                            ? 'info'
+                                            : ($code >= 200
+                                                ? 'success'
+                                                : 'secondary')));
+                        @endphp
+                        <tr>
+                            <td class="text-center">{{ $monitoringLogs->firstItem() + $key }}</td>
+                            <td class="text-nowrap">
+                                {{ $monitoringLog->created_at }}
+                                <div class="small text-muted">
+                                    {{ optional($monitoringLog->created_at)->diffForHumans() }}
+                                </div>
+                            </td>
+                            <td class="text-center">
+                                <span class="badge bg-{{ $badge }}">{{ $code }}</span>
+                            </td>
+                            <td class="text-end">
+                                {{ number_format($monitoringLog->response_time, 0) }} {{ __('time.miliseconds') }}
+                            </td>
+                            <td class="text-break">{{ $monitoringLog->response_message }}</td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+
+        <div class="mt-3">
+            {{ $monitoringLogs->appends(Request::except('page'))->links() }}
+        </div>
+    </div>
 @endsection

--- a/resources/views/vendors/create.blade.php
+++ b/resources/views/vendors/create.blade.php
@@ -3,21 +3,33 @@
 @section('title', __('vendor.create'))
 
 @section('content')
-<div class="row justify-content-center">
-    <div class="col-md-6">
-        <div class="card">
-            <div class="card-header">{{ __('vendor.create') }}</div>
-            {{ Form::open(['route' => 'vendors.store']) }}
-            <div class="card-body">
-                {!! FormField::text('name', ['required' => true, 'label' => __('vendor.name')]) !!}
-                {!! FormField::textarea('description', ['label' => __('vendor.description')]) !!}
+    <div class="container py-4">
+        <div class="row justify-content-center">
+            <div class="col-md-6">
+                <div class="card shadow-sm">
+                    <div class="card-header">{{ __('vendor.create') }}</div>
+
+                    {{ Form::open(['route' => 'vendors.store']) }}
+                    <div class="card-body">
+                        {!! FormField::text('name', [
+                            'required' => true,
+                            'label' => __('vendor.name'),
+                            'placeholder' => 'Acme, Inc.',
+                        ]) !!}
+
+                        {!! FormField::textarea('description', [
+                            'label' => __('vendor.description'),
+                            'rows' => 4,
+                        ]) !!}
+                    </div>
+
+                    <div class="card-footer d-flex justify-content-end gap-2">
+                        {{ Form::submit(__('app.create'), ['class' => 'btn btn-success']) }}
+                        {{ link_to_route('vendors.index', __('app.cancel'), [], ['class' => 'btn btn-link']) }}
+                    </div>
+                    {{ Form::close() }}
+                </div>
             </div>
-            <div class="card-footer">
-                {{ Form::submit(__('app.create'), ['class' => 'btn btn-success']) }}
-                {{ link_to_route('vendors.index', __('app.cancel'), [], ['class' => 'btn btn-link']) }}
-            </div>
-            {{ Form::close() }}
         </div>
     </div>
-</div>
 @endsection

--- a/resources/views/vendors/edit.blade.php
+++ b/resources/views/vendors/edit.blade.php
@@ -3,50 +3,67 @@
 @section('title', __('vendor.edit'))
 
 @section('content')
-<div class="row justify-content-center">
-    <div class="col-md-6">
-        @if (request('action') == 'delete' && $vendor)
-        @can('delete', $vendor)
-            <div class="card">
-                <div class="card-header">{{ __('vendor.delete') }}</div>
-                <div class="card-body">
-                    <label class="control-label text-primary">{{ __('vendor.name') }}</label>
-                    <p>{{ $vendor->name }}</p>
-                    <label class="control-label text-primary">{{ __('vendor.description') }}</label>
-                    <p>{{ $vendor->description }}</p>
-                    {!! $errors->first('vendor_id', '<span class="form-error small">:message</span>') !!}
-                </div>
-                <hr style="margin:0">
-                <div class="card-body text-danger">{{ __('vendor.delete_confirm') }}</div>
-                <div class="card-footer">
-                    {!! FormField::delete(
-                        ['route' => ['vendors.destroy', $vendor]],
-                        __('app.delete_confirm_button'),
-                        ['class' => 'btn btn-danger'],
-                        ['vendor_id' => $vendor->id]
-                    ) !!}
-                    {{ link_to_route('vendors.edit', __('app.cancel'), [$vendor], ['class' => 'btn btn-link']) }}
-                </div>
+    <div class="container py-4">
+        <div class="row justify-content-center">
+            <div class="col-md-6">
+
+                @if (request('action') == 'delete' && $vendor)
+                    @can('delete', $vendor)
+                        <div class="card shadow-sm">
+                            <div class="card-header">{{ __('vendor.delete') }}</div>
+
+                            <div class="card-body">
+                                <div class="mb-3">
+                                    <label class="form-label text-primary">{{ __('vendor.name') }}</label>
+                                    <p class="mb-0">{{ $vendor->name }}</p>
+                                </div>
+                                <div class="mb-0">
+                                    <label class="form-label text-primary">{{ __('vendor.description') }}</label>
+                                    <p class="mb-0">{{ $vendor->description }}</p>
+                                </div>
+
+                                @if ($errors->has('vendor_id'))
+                                    <div class="small text-danger mt-2">{{ $errors->first('vendor_id') }}</div>
+                                @endif
+                            </div>
+
+                            <div class="card-body text-danger border-top">
+                                {{ __('vendor.delete_confirm') }}
+                            </div>
+
+                            <div class="card-footer d-flex justify-content-between">
+                                {!! FormField::delete(
+                                    ['route' => ['vendors.destroy', $vendor]],
+                                    __('app.delete_confirm_button'),
+                                    ['class' => 'btn btn-danger'],
+                                    ['vendor_id' => $vendor->id],
+                                ) !!}
+                                {{ link_to_route('vendors.edit', __('app.cancel'), [$vendor], ['class' => 'btn btn-link']) }}
+                            </div>
+                        </div>
+                    @endcan
+                @else
+                    <div class="card shadow-sm">
+                        <div class="card-header">{{ __('vendor.edit') }}</div>
+
+                        {{ Form::model($vendor, ['route' => ['vendors.update', $vendor], 'method' => 'patch']) }}
+                        <div class="card-body">
+                            {!! FormField::text('name', ['required' => true, 'label' => __('vendor.name')]) !!}
+                            {!! FormField::textarea('description', ['label' => __('vendor.description'), 'rows' => 4]) !!}
+                        </div>
+
+                        <div class="card-footer d-flex align-items-center gap-2">
+                            {{ Form::submit(__('vendor.update'), ['class' => 'btn btn-warning']) }}
+                            {{ link_to_route('vendors.show', __('app.cancel'), [$vendor], ['class' => 'btn btn-link']) }}
+                            @can('delete', $vendor)
+                                {{ link_to_route('vendors.edit', __('app.delete'), [$vendor, 'action' => 'delete'], ['class' => 'btn btn-danger ms-auto', 'id' => 'del-vendor-' . $vendor->id]) }}
+                            @endcan
+                        </div>
+                        {{ Form::close() }}
+                    </div>
+                @endif
+
             </div>
-        @endcan
-        @else
-        <div class="card">
-            <div class="card-header">{{ __('vendor.edit') }}</div>
-            {{ Form::model($vendor, ['route' => ['vendors.update', $vendor], 'method' => 'patch']) }}
-            <div class="card-body">
-                {!! FormField::text('name', ['required' => true, 'label' => __('vendor.name')]) !!}
-                {!! FormField::textarea('description', ['label' => __('vendor.description')]) !!}
-            </div>
-            <div class="card-footer">
-                {{ Form::submit(__('vendor.update'), ['class' => 'btn btn-success']) }}
-                {{ link_to_route('vendors.show', __('app.cancel'), [$vendor], ['class' => 'btn btn-link']) }}
-                @can('delete', $vendor)
-                    {{ link_to_route('vendors.edit', __('app.delete'), [$vendor, 'action' => 'delete'], ['class' => 'btn btn-danger float-right', 'id' => 'del-vendor-'.$vendor->id]) }}
-                @endcan
-            </div>
-            {{ Form::close() }}
         </div>
     </div>
-</div>
-@endif
 @endsection

--- a/resources/views/vendors/index.blade.php
+++ b/resources/views/vendors/index.blade.php
@@ -3,55 +3,69 @@
 @section('title', __('vendor.list'))
 
 @section('content')
-<div class="mb-3">
-    <div class="float-end">
-        @can('create', new App\Models\Vendor)
-            {{ link_to_route('vendors.create', __('vendor.create'), [], ['class' => 'btn btn-success']) }}
-        @endcan
-    </div>
-    <h2 class="page-title">{{ __('vendor.list') }} <small>{{ __('app.total') }} : {{ $vendors->total() }} {{ __('vendor.vendor') }}</small></h2>
-</div>
+    <div class="container py-4">
+        <div class="d-flex align-items-center justify-content-between flex-wrap gap-2 mb-3">
+            <h2 class="h4 mb-0">
+                {{ __('vendor.list') }}
+                <small class="text-muted">
+                    {{ __('app.total') }} : {{ $vendors->total() }} {{ __('vendor.vendor') }}
+                </small>
+            </h2>
 
-<div class="row">
-    <div class="col-md-12">
-        <div class="card">
+            @can('create', new App\Models\Vendor())
+                {{ link_to_route('vendors.create', __('vendor.create'), [], ['class' => 'btn btn-success']) }}
+            @endcan
+        </div>
+
+        <div class="card shadow-sm">
             <div class="card-header">
                 {{ Form::open(['method' => 'get', 'class' => 'row row-cols-lg-auto g-3 align-items-center']) }}
                 <div class="col-12">
-                    {!! Form::text('q', request('q'), ['label' => false, 'placeholder' => __('vendor.search')]) !!}
+                    {!! Form::text('q', request('q'), [
+                        'label' => false,
+                        'placeholder' => __('vendor.search'),
+                        'class' => 'form-control',
+                    ]) !!}
                 </div>
-                <div class="col-12">
-                    {{ Form::submit(__('vendor.search'), ['class' => 'btn-secondary']) }}
-                    {{ link_to_route('vendors.index', __('app.reset'), [], ['class' => 'btn btn-link']) }}
+                <div class="col-12 d-flex gap-2">
+                    {{ Form::submit(__('vendor.search'), ['class' => 'btn btn-primary btn-sm']) }}
+                    {{ link_to_route('vendors.index', __('app.reset'), [], ['class' => 'btn btn-secondary btn-sm']) }}
                 </div>
                 {{ Form::close() }}
             </div>
-            <table class="table table-sm table-responsive-sm table-hover">
-                <thead>
-                    <tr>
-                        <th class="text-center">{{ __('app.table_no') }}</th>
-                        <th>{{ __('vendor.name') }}</th>
-                        <th>{{ __('vendor.description') }}</th>
-                        <th class="text-center">{{ __('app.action') }}</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    @foreach($vendors as $key => $vendor)
-                    <tr>
-                        <td class="text-center">{{ $vendors->firstItem() + $key }}</td>
-                        <td>{!! $vendor->name !!}</td>
-                        <td>{{ $vendor->description }}</td>
-                        <td class="text-center">
-                            @can('view', $vendor)
-                                <a href="{{ route('vendors.show', $vendor) }}" id="show-vendor-{{ $vendor->id }}">{{ __('app.show') }}</a>
-                            @endcan
-                        </td>
-                    </tr>
-                    @endforeach
-                </tbody>
-            </table>
-            <div class="card-body">{{ $vendors->appends(Request::except('page'))->render() }}</div>
+
+            <div class="table-responsive">
+                <table class="table table-sm table-hover align-middle mb-0">
+                    <thead>
+                        <tr>
+                            <th class="text-center" style="width:72px">{{ __('app.table_no') }}</th>
+                            <th style="width:25%">{{ __('vendor.name') }}</th>
+                            <th>{{ __('vendor.description') }}</th>
+                            <th class="text-center" style="width:120px">{{ __('app.action') }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach ($vendors as $key => $vendor)
+                            <tr>
+                                <td class="text-center">{{ $vendors->firstItem() + $key }}</td>
+                                <td>{{ $vendor->name }}</td> {{-- amankan output --}}
+                                <td class="text-break">{{ $vendor->description }}</td>
+                                <td class="text-center">
+                                    @can('view', $vendor)
+                                        <a href="{{ route('vendors.show', $vendor) }}" id="show-vendor-{{ $vendor->id }}">
+                                            {{ __('app.show') }}
+                                        </a>
+                                    @endcan
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="card-body">
+                {{ $vendors->appends(Request::except('page'))->render() }}
+            </div>
         </div>
     </div>
-</div>
 @endsection

--- a/resources/views/vendors/show.blade.php
+++ b/resources/views/vendors/show.blade.php
@@ -3,25 +3,37 @@
 @section('title', __('vendor.detail'))
 
 @section('content')
-<div class="row justify-content-center">
-    <div class="col-md-6">
-        <div class="card">
-            <div class="card-header">{{ __('vendor.detail') }}</div>
-            <div class="card-body">
-                <table class="table table-sm">
-                    <tbody>
-                        <tr><td>{{ __('vendor.name') }}</td><td>{{ $vendor->name }}</td></tr>
-                        <tr><td>{{ __('vendor.description') }}</td><td>{{ $vendor->description }}</td></tr>
-                    </tbody>
-                </table>
-            </div>
-            <div class="card-footer">
-                @can('update', $vendor)
-                    {{ link_to_route('vendors.edit', __('vendor.edit'), [$vendor], ['class' => 'btn btn-warning', 'id' => 'edit-vendor-'.$vendor->id]) }}
-                @endcan
-                {{ link_to_route('vendors.index', __('vendor.back_to_index'), [], ['class' => 'btn btn-link']) }}
+    <div class="container py-4">
+        <div class="row justify-content-center">
+            <div class="col-md-6">
+                <div class="card shadow-sm">
+                    <div class="card-header">{{ __('vendor.detail') }}</div>
+
+                    <div class="card-body p-0">
+                        <div class="table-responsive">
+                            <table class="table table-sm mb-0 align-middle">
+                                <tbody>
+                                    <tr>
+                                        <th class="w-25 text-muted">{{ __('vendor.name') }}</th>
+                                        <td>{{ $vendor->name }}</td>
+                                    </tr>
+                                    <tr>
+                                        <th class="text-muted">{{ __('vendor.description') }}</th>
+                                        <td class="text-break">{{ $vendor->description }}</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+
+                    <div class="card-footer d-flex justify-content-between">
+                        @can('update', $vendor)
+                            {{ link_to_route('vendors.edit', __('vendor.edit'), [$vendor], ['class' => 'btn btn-warning', 'id' => 'edit-vendor-' . $vendor->id]) }}
+                        @endcan
+                        {{ link_to_route('vendors.index', __('vendor.back_to_index'), [], ['class' => 'btn btn-link']) }}
+                    </div>
+                </div>
             </div>
         </div>
     </div>
-</div>
 @endsection

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,140 +1,1018 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
-    <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <title>Laravel</title>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <!-- Fonts -->
-        <link rel="preconnect" href="https://fonts.bunny.net">
-        <link href="https://fonts.bunny.net/css?family=figtree:400,600&display=swap" rel="stylesheet" />
+    <title>Laravel</title>
 
-        <!-- Styles -->
-        <style>
-            /* ! tailwindcss v3.2.4 | MIT License | https://tailwindcss.com */*,::after,::before{box-sizing:border-box;border-width:0;border-style:solid;border-color:#e5e7eb}::after,::before{--tw-content:''}html{line-height:1.5;-webkit-text-size-adjust:100%;-moz-tab-size:4;tab-size:4;font-family:Figtree, sans-serif;font-feature-settings:normal}body{margin:0;line-height:inherit}hr{height:0;color:inherit;border-top-width:1px}abbr:where([title]){-webkit-text-decoration:underline dotted;text-decoration:underline dotted}h1,h2,h3,h4,h5,h6{font-size:inherit;font-weight:inherit}a{color:inherit;text-decoration:inherit}b,strong{font-weight:bolder}code,kbd,pre,samp{font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;font-size:1em}small{font-size:80%}sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}sub{bottom:-.25em}sup{top:-.5em}table{text-indent:0;border-color:inherit;border-collapse:collapse}button,input,optgroup,select,textarea{font-family:inherit;font-size:100%;font-weight:inherit;line-height:inherit;color:inherit;margin:0;padding:0}button,select{text-transform:none}[type=button],[type=reset],[type=submit],button{-webkit-appearance:button;background-color:transparent;background-image:none}:-moz-focusring{outline:auto}:-moz-ui-invalid{box-shadow:none}progress{vertical-align:baseline}::-webkit-inner-spin-button,::-webkit-outer-spin-button{height:auto}[type=search]{-webkit-appearance:textfield;outline-offset:-2px}::-webkit-search-decoration{-webkit-appearance:none}::-webkit-file-upload-button{-webkit-appearance:button;font:inherit}summary{display:list-item}blockquote,dd,dl,figure,h1,h2,h3,h4,h5,h6,hr,p,pre{margin:0}fieldset{margin:0;padding:0}legend{padding:0}menu,ol,ul{list-style:none;margin:0;padding:0}textarea{resize:vertical}input::placeholder,textarea::placeholder{opacity:1;color:#9ca3af}[role=button],button{cursor:pointer}:disabled{cursor:default}audio,canvas,embed,iframe,img,object,svg,video{display:block;vertical-align:middle}img,video{max-width:100%;height:auto}[hidden]{display:none}*, ::before, ::after{--tw-border-spacing-x:0;--tw-border-spacing-y:0;--tw-translate-x:0;--tw-translate-y:0;--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;--tw-pan-x: ;--tw-pan-y: ;--tw-pinch-zoom: ;--tw-scroll-snap-strictness:proximity;--tw-ordinal: ;--tw-slashed-zero: ;--tw-numeric-figure: ;--tw-numeric-spacing: ;--tw-numeric-fraction: ;--tw-ring-inset: ;--tw-ring-offset-width:0px;--tw-ring-offset-color:#fff;--tw-ring-color:rgb(59 130 246 / 0.5);--tw-ring-offset-shadow:0 0 #0000;--tw-ring-shadow:0 0 #0000;--tw-shadow:0 0 #0000;--tw-shadow-colored:0 0 #0000;--tw-blur: ;--tw-brightness: ;--tw-contrast: ;--tw-grayscale: ;--tw-hue-rotate: ;--tw-invert: ;--tw-saturate: ;--tw-sepia: ;--tw-drop-shadow: ;--tw-backdrop-blur: ;--tw-backdrop-brightness: ;--tw-backdrop-contrast: ;--tw-backdrop-grayscale: ;--tw-backdrop-hue-rotate: ;--tw-backdrop-invert: ;--tw-backdrop-opacity: ;--tw-backdrop-saturate: ;--tw-backdrop-sepia: }::-webkit-backdrop{--tw-border-spacing-x:0;--tw-border-spacing-y:0;--tw-translate-x:0;--tw-translate-y:0;--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;--tw-pan-x: ;--tw-pan-y: ;--tw-pinch-zoom: ;--tw-scroll-snap-strictness:proximity;--tw-ordinal: ;--tw-slashed-zero: ;--tw-numeric-figure: ;--tw-numeric-spacing: ;--tw-numeric-fraction: ;--tw-ring-inset: ;--tw-ring-offset-width:0px;--tw-ring-offset-color:#fff;--tw-ring-color:rgb(59 130 246 / 0.5);--tw-ring-offset-shadow:0 0 #0000;--tw-ring-shadow:0 0 #0000;--tw-shadow:0 0 #0000;--tw-shadow-colored:0 0 #0000;--tw-blur: ;--tw-brightness: ;--tw-contrast: ;--tw-grayscale: ;--tw-hue-rotate: ;--tw-invert: ;--tw-saturate: ;--tw-sepia: ;--tw-drop-shadow: ;--tw-backdrop-blur: ;--tw-backdrop-brightness: ;--tw-backdrop-contrast: ;--tw-backdrop-grayscale: ;--tw-backdrop-hue-rotate: ;--tw-backdrop-invert: ;--tw-backdrop-opacity: ;--tw-backdrop-saturate: ;--tw-backdrop-sepia: }::backdrop{--tw-border-spacing-x:0;--tw-border-spacing-y:0;--tw-translate-x:0;--tw-translate-y:0;--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;--tw-pan-x: ;--tw-pan-y: ;--tw-pinch-zoom: ;--tw-scroll-snap-strictness:proximity;--tw-ordinal: ;--tw-slashed-zero: ;--tw-numeric-figure: ;--tw-numeric-spacing: ;--tw-numeric-fraction: ;--tw-ring-inset: ;--tw-ring-offset-width:0px;--tw-ring-offset-color:#fff;--tw-ring-color:rgb(59 130 246 / 0.5);--tw-ring-offset-shadow:0 0 #0000;--tw-ring-shadow:0 0 #0000;--tw-shadow:0 0 #0000;--tw-shadow-colored:0 0 #0000;--tw-blur: ;--tw-brightness: ;--tw-contrast: ;--tw-grayscale: ;--tw-hue-rotate: ;--tw-invert: ;--tw-saturate: ;--tw-sepia: ;--tw-drop-shadow: ;--tw-backdrop-blur: ;--tw-backdrop-brightness: ;--tw-backdrop-contrast: ;--tw-backdrop-grayscale: ;--tw-backdrop-hue-rotate: ;--tw-backdrop-invert: ;--tw-backdrop-opacity: ;--tw-backdrop-saturate: ;--tw-backdrop-sepia: }.relative{position:relative}.mx-auto{margin-left:auto;margin-right:auto}.mx-6{margin-left:1.5rem;margin-right:1.5rem}.ml-4{margin-left:1rem}.mt-16{margin-top:4rem}.mt-6{margin-top:1.5rem}.mt-4{margin-top:1rem}.-mt-px{margin-top:-1px}.mr-1{margin-right:0.25rem}.flex{display:flex}.inline-flex{display:inline-flex}.grid{display:grid}.h-16{height:4rem}.h-7{height:1.75rem}.h-6{height:1.5rem}.h-5{height:1.25rem}.min-h-screen{min-height:100vh}.w-auto{width:auto}.w-16{width:4rem}.w-7{width:1.75rem}.w-6{width:1.5rem}.w-5{width:1.25rem}.max-w-7xl{max-width:80rem}.shrink-0{flex-shrink:0}.scale-100{--tw-scale-x:1;--tw-scale-y:1;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.grid-cols-1{grid-template-columns:repeat(1, minmax(0, 1fr))}.items-center{align-items:center}.justify-center{justify-content:center}.gap-6{gap:1.5rem}.gap-4{gap:1rem}.self-center{align-self:center}.rounded-lg{border-radius:0.5rem}.rounded-full{border-radius:9999px}.bg-gray-100{--tw-bg-opacity:1;background-color:rgb(243 244 246 / var(--tw-bg-opacity))}.bg-white{--tw-bg-opacity:1;background-color:rgb(255 255 255 / var(--tw-bg-opacity))}.bg-red-50{--tw-bg-opacity:1;background-color:rgb(254 242 242 / var(--tw-bg-opacity))}.bg-dots-darker{background-image:url("data:image/svg+xml,%3Csvg width='30' height='30' viewBox='0 0 30 30' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.22676 0C1.91374 0 2.45351 0.539773 2.45351 1.22676C2.45351 1.91374 1.91374 2.45351 1.22676 2.45351C0.539773 2.45351 0 1.91374 0 1.22676C0 0.539773 0.539773 0 1.22676 0Z' fill='rgba(0,0,0,0.07)'/%3E%3C/svg%3E")}.from-gray-700\/50{--tw-gradient-from:rgb(55 65 81 / 0.5);--tw-gradient-to:rgb(55 65 81 / 0);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}.via-transparent{--tw-gradient-to:rgb(0 0 0 / 0);--tw-gradient-stops:var(--tw-gradient-from), transparent, var(--tw-gradient-to)}.bg-center{background-position:center}.stroke-red-500{stroke:#ef4444}.stroke-gray-400{stroke:#9ca3af}.p-6{padding:1.5rem}.px-6{padding-left:1.5rem;padding-right:1.5rem}.text-center{text-align:center}.text-right{text-align:right}.text-xl{font-size:1.25rem;line-height:1.75rem}.text-sm{font-size:0.875rem;line-height:1.25rem}.font-semibold{font-weight:600}.leading-relaxed{line-height:1.625}.text-gray-600{--tw-text-opacity:1;color:rgb(75 85 99 / var(--tw-text-opacity))}.text-gray-900{--tw-text-opacity:1;color:rgb(17 24 39 / var(--tw-text-opacity))}.text-gray-500{--tw-text-opacity:1;color:rgb(107 114 128 / var(--tw-text-opacity))}.underline{-webkit-text-decoration-line:underline;text-decoration-line:underline}.antialiased{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}.shadow-2xl{--tw-shadow:0 25px 50px -12px rgb(0 0 0 / 0.25);--tw-shadow-colored:0 25px 50px -12px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}.shadow-gray-500\/20{--tw-shadow-color:rgb(107 114 128 / 0.2);--tw-shadow:var(--tw-shadow-colored)}.transition-all{transition-property:all;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:150ms}.selection\:bg-red-500 *::selection{--tw-bg-opacity:1;background-color:rgb(239 68 68 / var(--tw-bg-opacity))}.selection\:text-white *::selection{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}.selection\:bg-red-500::selection{--tw-bg-opacity:1;background-color:rgb(239 68 68 / var(--tw-bg-opacity))}.selection\:text-white::selection{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}.hover\:text-gray-900:hover{--tw-text-opacity:1;color:rgb(17 24 39 / var(--tw-text-opacity))}.hover\:text-gray-700:hover{--tw-text-opacity:1;color:rgb(55 65 81 / var(--tw-text-opacity))}.focus\:rounded-sm:focus{border-radius:0.125rem}.focus\:outline:focus{outline-style:solid}.focus\:outline-2:focus{outline-width:2px}.focus\:outline-red-500:focus{outline-color:#ef4444}.group:hover .group-hover\:stroke-gray-600{stroke:#4b5563}.z-10{z-index: 10}@media (prefers-reduced-motion: no-preference){.motion-safe\:hover\:scale-\[1\.01\]:hover{--tw-scale-x:1.01;--tw-scale-y:1.01;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}}@media (prefers-color-scheme: dark){.dark\:bg-gray-900{--tw-bg-opacity:1;background-color:rgb(17 24 39 / var(--tw-bg-opacity))}.dark\:bg-gray-800\/50{background-color:rgb(31 41 55 / 0.5)}.dark\:bg-red-800\/20{background-color:rgb(153 27 27 / 0.2)}.dark\:bg-dots-lighter{background-image:url("data:image/svg+xml,%3Csvg width='30' height='30' viewBox='0 0 30 30' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.22676 0C1.91374 0 2.45351 0.539773 2.45351 1.22676C2.45351 1.91374 1.91374 2.45351 1.22676 2.45351C0.539773 2.45351 0 1.91374 0 1.22676C0 0.539773 0.539773 0 1.22676 0Z' fill='rgba(255,255,255,0.07)'/%3E%3C/svg%3E")}.dark\:bg-gradient-to-bl{background-image:linear-gradient(to bottom left, var(--tw-gradient-stops))}.dark\:stroke-gray-600{stroke:#4b5563}.dark\:text-gray-400{--tw-text-opacity:1;color:rgb(156 163 175 / var(--tw-text-opacity))}.dark\:text-white{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}.dark\:shadow-none{--tw-shadow:0 0 #0000;--tw-shadow-colored:0 0 #0000;box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}.dark\:ring-1{--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)}.dark\:ring-inset{--tw-ring-inset:inset}.dark\:ring-white\/5{--tw-ring-color:rgb(255 255 255 / 0.05)}.dark\:hover\:text-white:hover{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}.group:hover .dark\:group-hover\:stroke-gray-400{stroke:#9ca3af}}@media (min-width: 640px){.sm\:fixed{position:fixed}.sm\:top-0{top:0px}.sm\:right-0{right:0px}.sm\:ml-0{margin-left:0px}.sm\:flex{display:flex}.sm\:items-center{align-items:center}.sm\:justify-center{justify-content:center}.sm\:justify-between{justify-content:space-between}.sm\:text-left{text-align:left}.sm\:text-right{text-align:right}}@media (min-width: 768px){.md\:grid-cols-2{grid-template-columns:repeat(2, minmax(0, 1fr))}}@media (min-width: 1024px){.lg\:gap-8{gap:2rem}.lg\:p-8{padding:2rem}}
-        </style>
-    </head>
-    <body class="antialiased">
-        <div class="relative sm:flex sm:justify-center sm:items-center min-h-screen bg-dots-darker bg-center bg-gray-100 dark:bg-dots-lighter dark:bg-gray-900 selection:bg-red-500 selection:text-white">
-            @if (Route::has('login'))
-                <div class="sm:fixed sm:top-0 sm:right-0 p-6 text-right z-10">
-                    @auth
-                        <a href="{{ url('/home') }}" class="font-semibold text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Home</a>
-                    @else
-                        <a href="{{ route('login') }}" class="font-semibold text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Log in</a>
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.bunny.net">
+    <link href="https://fonts.bunny.net/css?family=figtree:400,600&display=swap" rel="stylesheet" />
 
-                        @if (Route::has('register'))
-                            <a href="{{ route('register') }}" class="ml-4 font-semibold text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Register</a>
-                        @endif
-                    @endauth
-                </div>
-            @endif
+    <!-- Styles -->
+    <style>
+        /* ! tailwindcss v3.2.4 | MIT License | https://tailwindcss.com */
+        *,
+        ::after,
+        ::before {
+            box-sizing: border-box;
+            border-width: 0;
+            border-style: solid;
+            border-color: #e5e7eb
+        }
 
-            <div class="max-w-7xl mx-auto p-6 lg:p-8">
-                <div class="flex justify-center">
-                    <svg viewBox="0 0 62 65" fill="none" xmlns="http://www.w3.org/2000/svg" class="h-16 w-auto bg-gray-100 dark:bg-gray-900">
-                        <path d="M61.8548 14.6253C61.8778 14.7102 61.8895 14.7978 61.8897 14.8858V28.5615C61.8898 28.737 61.8434 28.9095 61.7554 29.0614C61.6675 29.2132 61.5409 29.3392 61.3887 29.4265L49.9104 36.0351V49.1337C49.9104 49.4902 49.7209 49.8192 49.4118 49.9987L25.4519 63.7916C25.3971 63.8227 25.3372 63.8427 25.2774 63.8639C25.255 63.8714 25.2338 63.8851 25.2101 63.8913C25.0426 63.9354 24.8666 63.9354 24.6991 63.8913C24.6716 63.8838 24.6467 63.8689 24.6205 63.8589C24.5657 63.8389 24.5084 63.8215 24.456 63.7916L0.501061 49.9987C0.348882 49.9113 0.222437 49.7853 0.134469 49.6334C0.0465019 49.4816 0.000120578 49.3092 0 49.1337L0 8.10652C0 8.01678 0.0124642 7.92953 0.0348998 7.84477C0.0423783 7.8161 0.0598282 7.78993 0.0697995 7.76126C0.0884958 7.70891 0.105946 7.65531 0.133367 7.6067C0.152063 7.5743 0.179485 7.54812 0.20192 7.51821C0.230588 7.47832 0.256763 7.43719 0.290416 7.40229C0.319084 7.37362 0.356476 7.35243 0.388883 7.32751C0.425029 7.29759 0.457436 7.26518 0.498568 7.2415L12.4779 0.345059C12.6296 0.257786 12.8015 0.211853 12.9765 0.211853C13.1515 0.211853 13.3234 0.257786 13.475 0.345059L25.4531 7.2415H25.4556C25.4955 7.26643 25.5292 7.29759 25.5653 7.32626C25.5977 7.35119 25.6339 7.37362 25.6625 7.40104C25.6974 7.43719 25.7224 7.47832 25.7523 7.51821C25.7735 7.54812 25.8021 7.5743 25.8196 7.6067C25.8483 7.65656 25.8645 7.70891 25.8844 7.76126C25.8944 7.78993 25.9118 7.8161 25.9193 7.84602C25.9423 7.93096 25.954 8.01853 25.9542 8.10652V33.7317L35.9355 27.9844V14.8846C35.9355 14.7973 35.948 14.7088 35.9704 14.6253C35.9792 14.5954 35.9954 14.5692 36.0053 14.5405C36.0253 14.4882 36.0427 14.4346 36.0702 14.386C36.0888 14.3536 36.1163 14.3274 36.1375 14.2975C36.1674 14.2576 36.1923 14.2165 36.2272 14.1816C36.2559 14.1529 36.292 14.1317 36.3244 14.1068C36.3618 14.0769 36.3942 14.0445 36.4341 14.0208L48.4147 7.12434C48.5663 7.03694 48.7383 6.99094 48.9133 6.99094C49.0883 6.99094 49.2602 7.03694 49.4118 7.12434L61.3899 14.0208C61.4323 14.0457 61.4647 14.0769 61.5021 14.1055C61.5333 14.1305 61.5694 14.1529 61.5981 14.1803C61.633 14.2165 61.6579 14.2576 61.6878 14.2975C61.7103 14.3274 61.7377 14.3536 61.7551 14.386C61.7838 14.4346 61.8 14.4882 61.8199 14.5405C61.8312 14.5692 61.8474 14.5954 61.8548 14.6253ZM59.893 27.9844V16.6121L55.7013 19.0252L49.9104 22.3593V33.7317L59.8942 27.9844H59.893ZM47.9149 48.5566V37.1768L42.2187 40.4299L25.953 49.7133V61.2003L47.9149 48.5566ZM1.99677 9.83281V48.5566L23.9562 61.199V49.7145L12.4841 43.2219L12.4804 43.2194L12.4754 43.2169C12.4368 43.1945 12.4044 43.1621 12.3682 43.1347C12.3371 43.1097 12.3009 43.0898 12.2735 43.0624L12.271 43.0586C12.2386 43.0275 12.2162 42.9888 12.1887 42.9539C12.1638 42.9203 12.1339 42.8916 12.114 42.8567L12.1127 42.853C12.0903 42.8156 12.0766 42.7707 12.0604 42.7283C12.0442 42.6909 12.023 42.656 12.013 42.6161C12.0005 42.5688 11.998 42.5177 11.9931 42.4691C11.9881 42.4317 11.9781 42.3943 11.9781 42.3569V15.5801L6.18848 12.2446L1.99677 9.83281ZM12.9777 2.36177L2.99764 8.10652L12.9752 13.8513L22.9541 8.10527L12.9752 2.36177H12.9777ZM18.1678 38.2138L23.9574 34.8809V9.83281L19.7657 12.2459L13.9749 15.5801V40.6281L18.1678 38.2138ZM48.9133 9.14105L38.9344 14.8858L48.9133 20.6305L58.8909 14.8846L48.9133 9.14105ZM47.9149 22.3593L42.124 19.0252L37.9323 16.6121V27.9844L43.7219 31.3174L47.9149 33.7317V22.3593ZM24.9533 47.987L39.59 39.631L46.9065 35.4555L36.9352 29.7145L25.4544 36.3242L14.9907 42.3482L24.9533 47.987Z" fill="#FF2D20"/>
-                    </svg>
-                </div>
+        ::after,
+        ::before {
+            --tw-content: ''
+        }
 
-                <div class="mt-16">
-                    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8">
-                        <a href="https://laravel.com/docs" class="scale-100 p-6 bg-white dark:bg-gray-800/50 dark:bg-gradient-to-bl from-gray-700/50 via-transparent dark:ring-1 dark:ring-inset dark:ring-white/5 rounded-lg shadow-2xl shadow-gray-500/20 dark:shadow-none flex motion-safe:hover:scale-[1.01] transition-all duration-250 focus:outline focus:outline-2 focus:outline-red-500">
-                            <div>
-                                <div class="h-16 w-16 bg-red-50 dark:bg-red-800/20 flex items-center justify-center rounded-full">
-                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" class="w-7 h-7 stroke-red-500">
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
-                                    </svg>
-                                </div>
+        html {
+            line-height: 1.5;
+            -webkit-text-size-adjust: 100%;
+            -moz-tab-size: 4;
+            tab-size: 4;
+            font-family: Figtree, sans-serif;
+            font-feature-settings: normal
+        }
 
-                                <h2 class="mt-6 text-xl font-semibold text-gray-900 dark:text-white">Documentation</h2>
+        body {
+            margin: 0;
+            line-height: inherit
+        }
 
-                                <p class="mt-4 text-gray-500 dark:text-gray-400 text-sm leading-relaxed">
-                                    Laravel has wonderful documentation covering every aspect of the framework. Whether you are a newcomer or have prior experience with Laravel, we recommend reading our documentation from beginning to end.
-                                </p>
-                            </div>
+        hr {
+            height: 0;
+            color: inherit;
+            border-top-width: 1px
+        }
 
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" class="self-center shrink-0 stroke-red-500 w-6 h-6 mx-6">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12h15m0 0l-6.75-6.75M19.5 12l-6.75 6.75" />
-                            </svg>
-                        </a>
+        abbr:where([title]) {
+            -webkit-text-decoration: underline dotted;
+            text-decoration: underline dotted
+        }
 
-                        <a href="https://laracasts.com" class="scale-100 p-6 bg-white dark:bg-gray-800/50 dark:bg-gradient-to-bl from-gray-700/50 via-transparent dark:ring-1 dark:ring-inset dark:ring-white/5 rounded-lg shadow-2xl shadow-gray-500/20 dark:shadow-none flex motion-safe:hover:scale-[1.01] transition-all duration-250 focus:outline focus:outline-2 focus:outline-red-500">
-                            <div>
-                                <div class="h-16 w-16 bg-red-50 dark:bg-red-800/20 flex items-center justify-center rounded-full">
-                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" class="w-7 h-7 stroke-red-500">
-                                        <path stroke-linecap="round" d="M15.75 10.5l4.72-4.72a.75.75 0 011.28.53v11.38a.75.75 0 01-1.28.53l-4.72-4.72M4.5 18.75h9a2.25 2.25 0 002.25-2.25v-9a2.25 2.25 0 00-2.25-2.25h-9A2.25 2.25 0 002.25 7.5v9a2.25 2.25 0 002.25 2.25z" />
-                                    </svg>
-                                </div>
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6 {
+            font-size: inherit;
+            font-weight: inherit
+        }
 
-                                <h2 class="mt-6 text-xl font-semibold text-gray-900 dark:text-white">Laracasts</h2>
+        a {
+            color: inherit;
+            text-decoration: inherit
+        }
 
-                                <p class="mt-4 text-gray-500 dark:text-gray-400 text-sm leading-relaxed">
-                                    Laracasts offers thousands of video tutorials on Laravel, PHP, and JavaScript development. Check them out, see for yourself, and massively level up your development skills in the process.
-                                </p>
-                            </div>
+        b,
+        strong {
+            font-weight: bolder
+        }
 
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" class="self-center shrink-0 stroke-red-500 w-6 h-6 mx-6">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12h15m0 0l-6.75-6.75M19.5 12l-6.75 6.75" />
-                            </svg>
-                        </a>
+        code,
+        kbd,
+        pre,
+        samp {
+            font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+            font-size: 1em
+        }
 
-                        <a href="https://laravel-news.com" class="scale-100 p-6 bg-white dark:bg-gray-800/50 dark:bg-gradient-to-bl from-gray-700/50 via-transparent dark:ring-1 dark:ring-inset dark:ring-white/5 rounded-lg shadow-2xl shadow-gray-500/20 dark:shadow-none flex motion-safe:hover:scale-[1.01] transition-all duration-250 focus:outline focus:outline-2 focus:outline-red-500">
-                            <div>
-                                <div class="h-16 w-16 bg-red-50 dark:bg-red-800/20 flex items-center justify-center rounded-full">
-                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" class="w-7 h-7 stroke-red-500">
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 7.5h1.5m-1.5 3h1.5m-7.5 3h7.5m-7.5 3h7.5m3-9h3.375c.621 0 1.125.504 1.125 1.125V18a2.25 2.25 0 01-2.25 2.25M16.5 7.5V18a2.25 2.25 0 002.25 2.25M16.5 7.5V4.875c0-.621-.504-1.125-1.125-1.125H4.125C3.504 3.75 3 4.254 3 4.875V18a2.25 2.25 0 002.25 2.25h13.5M6 7.5h3v3H6v-3z" />
-                                    </svg>
-                                </div>
+        small {
+            font-size: 80%
+        }
 
-                                <h2 class="mt-6 text-xl font-semibold text-gray-900 dark:text-white">Laravel News</h2>
+        sub,
+        sup {
+            font-size: 75%;
+            line-height: 0;
+            position: relative;
+            vertical-align: baseline
+        }
 
-                                <p class="mt-4 text-gray-500 dark:text-gray-400 text-sm leading-relaxed">
-                                    Laravel News is a community driven portal and newsletter aggregating all of the latest and most important news in the Laravel ecosystem, including new package releases and tutorials.
-                                </p>
-                            </div>
+        sub {
+            bottom: -.25em
+        }
 
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" class="self-center shrink-0 stroke-red-500 w-6 h-6 mx-6">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12h15m0 0l-6.75-6.75M19.5 12l-6.75 6.75" />
-                            </svg>
-                        </a>
+        sup {
+            top: -.5em
+        }
 
-                        <div class="scale-100 p-6 bg-white dark:bg-gray-800/50 dark:bg-gradient-to-bl from-gray-700/50 via-transparent dark:ring-1 dark:ring-inset dark:ring-white/5 rounded-lg shadow-2xl shadow-gray-500/20 dark:shadow-none flex motion-safe:hover:scale-[1.01] transition-all duration-250 focus:outline focus:outline-2 focus:outline-red-500">
-                            <div>
-                                <div class="h-16 w-16 bg-red-50 dark:bg-red-800/20 flex items-center justify-center rounded-full">
-                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" class="w-7 h-7 stroke-red-500">
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M6.115 5.19l.319 1.913A6 6 0 008.11 10.36L9.75 12l-.387.775c-.217.433-.132.956.21 1.298l1.348 1.348c.21.21.329.497.329.795v1.089c0 .426.24.815.622 1.006l.153.076c.433.217.956.132 1.298-.21l.723-.723a8.7 8.7 0 002.288-4.042 1.087 1.087 0 00-.358-1.099l-1.33-1.108c-.251-.21-.582-.299-.905-.245l-1.17.195a1.125 1.125 0 01-.98-.314l-.295-.295a1.125 1.125 0 010-1.591l.13-.132a1.125 1.125 0 011.3-.21l.603.302a.809.809 0 001.086-1.086L14.25 7.5l1.256-.837a4.5 4.5 0 001.528-1.732l.146-.292M6.115 5.19A9 9 0 1017.18 4.64M6.115 5.19A8.965 8.965 0 0112 3c1.929 0 3.716.607 5.18 1.64" />
-                                    </svg>
-                                </div>
+        table {
+            text-indent: 0;
+            border-color: inherit;
+            border-collapse: collapse
+        }
 
-                                <h2 class="mt-6 text-xl font-semibold text-gray-900 dark:text-white">Vibrant Ecosystem</h2>
+        button,
+        input,
+        optgroup,
+        select,
+        textarea {
+            font-family: inherit;
+            font-size: 100%;
+            font-weight: inherit;
+            line-height: inherit;
+            color: inherit;
+            margin: 0;
+            padding: 0
+        }
 
-                                <p class="mt-4 text-gray-500 dark:text-gray-400 text-sm leading-relaxed">
-                                    Laravel's robust library of first-party tools and libraries, such as <a href="https://forge.laravel.com" class="underline hover:text-gray-700 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Forge</a>, <a href="https://vapor.laravel.com" class="underline hover:text-gray-700 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Vapor</a>, <a href="https://nova.laravel.com" class="underline hover:text-gray-700 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Nova</a>, and <a href="https://envoyer.io" class="underline hover:text-gray-700 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Envoyer</a> help you take your projects to the next level. Pair them with powerful open source libraries like <a href="https://laravel.com/docs/billing" class="underline hover:text-gray-700 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Cashier</a>, <a href="https://laravel.com/docs/dusk" class="underline hover:text-gray-700 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Dusk</a>, <a href="https://laravel.com/docs/broadcasting" class="underline hover:text-gray-700 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Echo</a>, <a href="https://laravel.com/docs/horizon" class="underline hover:text-gray-700 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Horizon</a>, <a href="https://laravel.com/docs/sanctum" class="underline hover:text-gray-700 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Sanctum</a>, <a href="https://laravel.com/docs/telescope" class="underline hover:text-gray-700 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Telescope</a>, and more.
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+        button,
+        select {
+            text-transform: none
+        }
 
-                <div class="flex justify-center mt-16 px-0 sm:items-center sm:justify-between">
-                    <div class="text-center text-sm text-gray-500 dark:text-gray-400 sm:text-left">
-                        <div class="flex items-center gap-4">
-                            <a href="https://github.com/sponsors/taylorotwell" class="group inline-flex items-center hover:text-gray-700 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">
-                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" class="-mt-px mr-1 w-5 h-5 stroke-gray-400 dark:stroke-gray-600 group-hover:stroke-gray-600 dark:group-hover:stroke-gray-400">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z" />
+        [type=button],
+        [type=reset],
+        [type=submit],
+        button {
+            -webkit-appearance: button;
+            background-color: transparent;
+            background-image: none
+        }
+
+        :-moz-focusring {
+            outline: auto
+        }
+
+        :-moz-ui-invalid {
+            box-shadow: none
+        }
+
+        progress {
+            vertical-align: baseline
+        }
+
+        ::-webkit-inner-spin-button,
+        ::-webkit-outer-spin-button {
+            height: auto
+        }
+
+        [type=search] {
+            -webkit-appearance: textfield;
+            outline-offset: -2px
+        }
+
+        ::-webkit-search-decoration {
+            -webkit-appearance: none
+        }
+
+        ::-webkit-file-upload-button {
+            -webkit-appearance: button;
+            font: inherit
+        }
+
+        summary {
+            display: list-item
+        }
+
+        blockquote,
+        dd,
+        dl,
+        figure,
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6,
+        hr,
+        p,
+        pre {
+            margin: 0
+        }
+
+        fieldset {
+            margin: 0;
+            padding: 0
+        }
+
+        legend {
+            padding: 0
+        }
+
+        menu,
+        ol,
+        ul {
+            list-style: none;
+            margin: 0;
+            padding: 0
+        }
+
+        textarea {
+            resize: vertical
+        }
+
+        input::placeholder,
+        textarea::placeholder {
+            opacity: 1;
+            color: #9ca3af
+        }
+
+        [role=button],
+        button {
+            cursor: pointer
+        }
+
+        :disabled {
+            cursor: default
+        }
+
+        audio,
+        canvas,
+        embed,
+        iframe,
+        img,
+        object,
+        svg,
+        video {
+            display: block;
+            vertical-align: middle
+        }
+
+        img,
+        video {
+            max-width: 100%;
+            height: auto
+        }
+
+        [hidden] {
+            display: none
+        }
+
+        *,
+        ::before,
+        ::after {
+            --tw-border-spacing-x: 0;
+            --tw-border-spacing-y: 0;
+            --tw-translate-x: 0;
+            --tw-translate-y: 0;
+            --tw-rotate: 0;
+            --tw-skew-x: 0;
+            --tw-skew-y: 0;
+            --tw-scale-x: 1;
+            --tw-scale-y: 1;
+            --tw-pan-x: ;
+            --tw-pan-y: ;
+            --tw-pinch-zoom: ;
+            --tw-scroll-snap-strictness: proximity;
+            --tw-ordinal: ;
+            --tw-slashed-zero: ;
+            --tw-numeric-figure: ;
+            --tw-numeric-spacing: ;
+            --tw-numeric-fraction: ;
+            --tw-ring-inset: ;
+            --tw-ring-offset-width: 0px;
+            --tw-ring-offset-color: #fff;
+            --tw-ring-color: rgb(59 130 246 / 0.5);
+            --tw-ring-offset-shadow: 0 0 #0000;
+            --tw-ring-shadow: 0 0 #0000;
+            --tw-shadow: 0 0 #0000;
+            --tw-shadow-colored: 0 0 #0000;
+            --tw-blur: ;
+            --tw-brightness: ;
+            --tw-contrast: ;
+            --tw-grayscale: ;
+            --tw-hue-rotate: ;
+            --tw-invert: ;
+            --tw-saturate: ;
+            --tw-sepia: ;
+            --tw-drop-shadow: ;
+            --tw-backdrop-blur: ;
+            --tw-backdrop-brightness: ;
+            --tw-backdrop-contrast: ;
+            --tw-backdrop-grayscale: ;
+            --tw-backdrop-hue-rotate: ;
+            --tw-backdrop-invert: ;
+            --tw-backdrop-opacity: ;
+            --tw-backdrop-saturate: ;
+            --tw-backdrop-sepia:
+        }
+
+        ::-webkit-backdrop {
+            --tw-border-spacing-x: 0;
+            --tw-border-spacing-y: 0;
+            --tw-translate-x: 0;
+            --tw-translate-y: 0;
+            --tw-rotate: 0;
+            --tw-skew-x: 0;
+            --tw-skew-y: 0;
+            --tw-scale-x: 1;
+            --tw-scale-y: 1;
+            --tw-pan-x: ;
+            --tw-pan-y: ;
+            --tw-pinch-zoom: ;
+            --tw-scroll-snap-strictness: proximity;
+            --tw-ordinal: ;
+            --tw-slashed-zero: ;
+            --tw-numeric-figure: ;
+            --tw-numeric-spacing: ;
+            --tw-numeric-fraction: ;
+            --tw-ring-inset: ;
+            --tw-ring-offset-width: 0px;
+            --tw-ring-offset-color: #fff;
+            --tw-ring-color: rgb(59 130 246 / 0.5);
+            --tw-ring-offset-shadow: 0 0 #0000;
+            --tw-ring-shadow: 0 0 #0000;
+            --tw-shadow: 0 0 #0000;
+            --tw-shadow-colored: 0 0 #0000;
+            --tw-blur: ;
+            --tw-brightness: ;
+            --tw-contrast: ;
+            --tw-grayscale: ;
+            --tw-hue-rotate: ;
+            --tw-invert: ;
+            --tw-saturate: ;
+            --tw-sepia: ;
+            --tw-drop-shadow: ;
+            --tw-backdrop-blur: ;
+            --tw-backdrop-brightness: ;
+            --tw-backdrop-contrast: ;
+            --tw-backdrop-grayscale: ;
+            --tw-backdrop-hue-rotate: ;
+            --tw-backdrop-invert: ;
+            --tw-backdrop-opacity: ;
+            --tw-backdrop-saturate: ;
+            --tw-backdrop-sepia:
+        }
+
+        ::backdrop {
+            --tw-border-spacing-x: 0;
+            --tw-border-spacing-y: 0;
+            --tw-translate-x: 0;
+            --tw-translate-y: 0;
+            --tw-rotate: 0;
+            --tw-skew-x: 0;
+            --tw-skew-y: 0;
+            --tw-scale-x: 1;
+            --tw-scale-y: 1;
+            --tw-pan-x: ;
+            --tw-pan-y: ;
+            --tw-pinch-zoom: ;
+            --tw-scroll-snap-strictness: proximity;
+            --tw-ordinal: ;
+            --tw-slashed-zero: ;
+            --tw-numeric-figure: ;
+            --tw-numeric-spacing: ;
+            --tw-numeric-fraction: ;
+            --tw-ring-inset: ;
+            --tw-ring-offset-width: 0px;
+            --tw-ring-offset-color: #fff;
+            --tw-ring-color: rgb(59 130 246 / 0.5);
+            --tw-ring-offset-shadow: 0 0 #0000;
+            --tw-ring-shadow: 0 0 #0000;
+            --tw-shadow: 0 0 #0000;
+            --tw-shadow-colored: 0 0 #0000;
+            --tw-blur: ;
+            --tw-brightness: ;
+            --tw-contrast: ;
+            --tw-grayscale: ;
+            --tw-hue-rotate: ;
+            --tw-invert: ;
+            --tw-saturate: ;
+            --tw-sepia: ;
+            --tw-drop-shadow: ;
+            --tw-backdrop-blur: ;
+            --tw-backdrop-brightness: ;
+            --tw-backdrop-contrast: ;
+            --tw-backdrop-grayscale: ;
+            --tw-backdrop-hue-rotate: ;
+            --tw-backdrop-invert: ;
+            --tw-backdrop-opacity: ;
+            --tw-backdrop-saturate: ;
+            --tw-backdrop-sepia:
+        }
+
+        .relative {
+            position: relative
+        }
+
+        .mx-auto {
+            margin-left: auto;
+            margin-right: auto
+        }
+
+        .mx-6 {
+            margin-left: 1.5rem;
+            margin-right: 1.5rem
+        }
+
+        .ml-4 {
+            margin-left: 1rem
+        }
+
+        .mt-16 {
+            margin-top: 4rem
+        }
+
+        .mt-6 {
+            margin-top: 1.5rem
+        }
+
+        .mt-4 {
+            margin-top: 1rem
+        }
+
+        .-mt-px {
+            margin-top: -1px
+        }
+
+        .mr-1 {
+            margin-right: 0.25rem
+        }
+
+        .flex {
+            display: flex
+        }
+
+        .inline-flex {
+            display: inline-flex
+        }
+
+        .grid {
+            display: grid
+        }
+
+        .h-16 {
+            height: 4rem
+        }
+
+        .h-7 {
+            height: 1.75rem
+        }
+
+        .h-6 {
+            height: 1.5rem
+        }
+
+        .h-5 {
+            height: 1.25rem
+        }
+
+        .min-h-screen {
+            min-height: 100vh
+        }
+
+        .w-auto {
+            width: auto
+        }
+
+        .w-16 {
+            width: 4rem
+        }
+
+        .w-7 {
+            width: 1.75rem
+        }
+
+        .w-6 {
+            width: 1.5rem
+        }
+
+        .w-5 {
+            width: 1.25rem
+        }
+
+        .max-w-7xl {
+            max-width: 80rem
+        }
+
+        .shrink-0 {
+            flex-shrink: 0
+        }
+
+        .scale-100 {
+            --tw-scale-x: 1;
+            --tw-scale-y: 1;
+            transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))
+        }
+
+        .grid-cols-1 {
+            grid-template-columns: repeat(1, minmax(0, 1fr))
+        }
+
+        .items-center {
+            align-items: center
+        }
+
+        .justify-center {
+            justify-content: center
+        }
+
+        .gap-6 {
+            gap: 1.5rem
+        }
+
+        .gap-4 {
+            gap: 1rem
+        }
+
+        .self-center {
+            align-self: center
+        }
+
+        .rounded-lg {
+            border-radius: 0.5rem
+        }
+
+        .rounded-full {
+            border-radius: 9999px
+        }
+
+        .bg-gray-100 {
+            --tw-bg-opacity: 1;
+            background-color: rgb(243 244 246 / var(--tw-bg-opacity))
+        }
+
+        .bg-white {
+            --tw-bg-opacity: 1;
+            background-color: rgb(255 255 255 / var(--tw-bg-opacity))
+        }
+
+        .bg-red-50 {
+            --tw-bg-opacity: 1;
+            background-color: rgb(254 242 242 / var(--tw-bg-opacity))
+        }
+
+        .bg-dots-darker {
+            background-image: url("data:image/svg+xml,%3Csvg width='30' height='30' viewBox='0 0 30 30' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.22676 0C1.91374 0 2.45351 0.539773 2.45351 1.22676C2.45351 1.91374 1.91374 2.45351 1.22676 2.45351C0.539773 2.45351 0 1.91374 0 1.22676C0 0.539773 0.539773 0 1.22676 0Z' fill='rgba(0,0,0,0.07)'/%3E%3C/svg%3E")
+        }
+
+        .from-gray-700\/50 {
+            --tw-gradient-from: rgb(55 65 81 / 0.5);
+            --tw-gradient-to: rgb(55 65 81 / 0);
+            --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to)
+        }
+
+        .via-transparent {
+            --tw-gradient-to: rgb(0 0 0 / 0);
+            --tw-gradient-stops: var(--tw-gradient-from), transparent, var(--tw-gradient-to)
+        }
+
+        .bg-center {
+            background-position: center
+        }
+
+        .stroke-red-500 {
+            stroke: #ef4444
+        }
+
+        .stroke-gray-400 {
+            stroke: #9ca3af
+        }
+
+        .p-6 {
+            padding: 1.5rem
+        }
+
+        .px-6 {
+            padding-left: 1.5rem;
+            padding-right: 1.5rem
+        }
+
+        .text-center {
+            text-align: center
+        }
+
+        .text-right {
+            text-align: right
+        }
+
+        .text-xl {
+            font-size: 1.25rem;
+            line-height: 1.75rem
+        }
+
+        .text-sm {
+            font-size: 0.875rem;
+            line-height: 1.25rem
+        }
+
+        .font-semibold {
+            font-weight: 600
+        }
+
+        .leading-relaxed {
+            line-height: 1.625
+        }
+
+        .text-gray-600 {
+            --tw-text-opacity: 1;
+            color: rgb(75 85 99 / var(--tw-text-opacity))
+        }
+
+        .text-gray-900 {
+            --tw-text-opacity: 1;
+            color: rgb(17 24 39 / var(--tw-text-opacity))
+        }
+
+        .text-gray-500 {
+            --tw-text-opacity: 1;
+            color: rgb(107 114 128 / var(--tw-text-opacity))
+        }
+
+        .underline {
+            -webkit-text-decoration-line: underline;
+            text-decoration-line: underline
+        }
+
+        .antialiased {
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale
+        }
+
+        .shadow-2xl {
+            --tw-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.25);
+            --tw-shadow-colored: 0 25px 50px -12px var(--tw-shadow-color);
+            box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)
+        }
+
+        .shadow-gray-500\/20 {
+            --tw-shadow-color: rgb(107 114 128 / 0.2);
+            --tw-shadow: var(--tw-shadow-colored)
+        }
+
+        .transition-all {
+            transition-property: all;
+            transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+            transition-duration: 150ms
+        }
+
+        .selection\:bg-red-500 *::selection {
+            --tw-bg-opacity: 1;
+            background-color: rgb(239 68 68 / var(--tw-bg-opacity))
+        }
+
+        .selection\:text-white *::selection {
+            --tw-text-opacity: 1;
+            color: rgb(255 255 255 / var(--tw-text-opacity))
+        }
+
+        .selection\:bg-red-500::selection {
+            --tw-bg-opacity: 1;
+            background-color: rgb(239 68 68 / var(--tw-bg-opacity))
+        }
+
+        .selection\:text-white::selection {
+            --tw-text-opacity: 1;
+            color: rgb(255 255 255 / var(--tw-text-opacity))
+        }
+
+        .hover\:text-gray-900:hover {
+            --tw-text-opacity: 1;
+            color: rgb(17 24 39 / var(--tw-text-opacity))
+        }
+
+        .hover\:text-gray-700:hover {
+            --tw-text-opacity: 1;
+            color: rgb(55 65 81 / var(--tw-text-opacity))
+        }
+
+        .focus\:rounded-sm:focus {
+            border-radius: 0.125rem
+        }
+
+        .focus\:outline:focus {
+            outline-style: solid
+        }
+
+        .focus\:outline-2:focus {
+            outline-width: 2px
+        }
+
+        .focus\:outline-red-500:focus {
+            outline-color: #ef4444
+        }
+
+        .group:hover .group-hover\:stroke-gray-600 {
+            stroke: #4b5563
+        }
+
+        .z-10 {
+            z-index: 10
+        }
+
+        @media (prefers-reduced-motion: no-preference) {
+            .motion-safe\:hover\:scale-\[1\.01\]:hover {
+                --tw-scale-x: 1.01;
+                --tw-scale-y: 1.01;
+                transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))
+            }
+        }
+
+        @media (prefers-color-scheme: dark) {
+            .dark\:bg-gray-900 {
+                --tw-bg-opacity: 1;
+                background-color: rgb(17 24 39 / var(--tw-bg-opacity))
+            }
+
+            .dark\:bg-gray-800\/50 {
+                background-color: rgb(31 41 55 / 0.5)
+            }
+
+            .dark\:bg-red-800\/20 {
+                background-color: rgb(153 27 27 / 0.2)
+            }
+
+            .dark\:bg-dots-lighter {
+                background-image: url("data:image/svg+xml,%3Csvg width='30' height='30' viewBox='0 0 30 30' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.22676 0C1.91374 0 2.45351 0.539773 2.45351 1.22676C2.45351 1.91374 1.91374 2.45351 1.22676 2.45351C0.539773 2.45351 0 1.91374 0 1.22676C0 0.539773 0.539773 0 1.22676 0Z' fill='rgba(255,255,255,0.07)'/%3E%3C/svg%3E")
+            }
+
+            .dark\:bg-gradient-to-bl {
+                background-image: linear-gradient(to bottom left, var(--tw-gradient-stops))
+            }
+
+            .dark\:stroke-gray-600 {
+                stroke: #4b5563
+            }
+
+            .dark\:text-gray-400 {
+                --tw-text-opacity: 1;
+                color: rgb(156 163 175 / var(--tw-text-opacity))
+            }
+
+            .dark\:text-white {
+                --tw-text-opacity: 1;
+                color: rgb(255 255 255 / var(--tw-text-opacity))
+            }
+
+            .dark\:shadow-none {
+                --tw-shadow: 0 0 #0000;
+                --tw-shadow-colored: 0 0 #0000;
+                box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)
+            }
+
+            .dark\:ring-1 {
+                --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+                --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+                box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)
+            }
+
+            .dark\:ring-inset {
+                --tw-ring-inset: inset
+            }
+
+            .dark\:ring-white\/5 {
+                --tw-ring-color: rgb(255 255 255 / 0.05)
+            }
+
+            .dark\:hover\:text-white:hover {
+                --tw-text-opacity: 1;
+                color: rgb(255 255 255 / var(--tw-text-opacity))
+            }
+
+            .group:hover .dark\:group-hover\:stroke-gray-400 {
+                stroke: #9ca3af
+            }
+        }
+
+        @media (min-width: 640px) {
+            .sm\:fixed {
+                position: fixed
+            }
+
+            .sm\:top-0 {
+                top: 0px
+            }
+
+            .sm\:right-0 {
+                right: 0px
+            }
+
+            .sm\:ml-0 {
+                margin-left: 0px
+            }
+
+            .sm\:flex {
+                display: flex
+            }
+
+            .sm\:items-center {
+                align-items: center
+            }
+
+            .sm\:justify-center {
+                justify-content: center
+            }
+
+            .sm\:justify-between {
+                justify-content: space-between
+            }
+
+            .sm\:text-left {
+                text-align: left
+            }
+
+            .sm\:text-right {
+                text-align: right
+            }
+        }
+
+        @media (min-width: 768px) {
+            .md\:grid-cols-2 {
+                grid-template-columns: repeat(2, minmax(0, 1fr))
+            }
+        }
+
+        @media (min-width: 1024px) {
+            .lg\:gap-8 {
+                gap: 2rem
+            }
+
+            .lg\:p-8 {
+                padding: 2rem
+            }
+        }
+    </style>
+</head>
+
+<body class="antialiased">
+    <div
+        class="relative sm:flex sm:justify-center sm:items-center min-h-screen bg-dots-darker bg-center bg-gray-100 dark:bg-dots-lighter dark:bg-gray-900 selection:bg-red-500 selection:text-white">
+        @if (Route::has('login'))
+            <div class="sm:fixed sm:top-0 sm:right-0 p-6 text-right z-10">
+                @auth
+                    <a href="{{ url('/home') }}"
+                        class="font-semibold text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Home</a>
+                @else
+                    <a href="{{ route('login') }}"
+                        class="font-semibold text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Log
+                        in</a>
+
+                    @if (Route::has('register'))
+                        <a href="{{ route('register') }}"
+                            class="ml-4 font-semibold text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Register</a>
+                    @endif
+                @endauth
+            </div>
+        @endif
+
+        <div class="max-w-7xl mx-auto p-6 lg:p-8">
+            <div class="flex justify-center">
+                <svg viewBox="0 0 62 65" fill="none" xmlns="http://www.w3.org/2000/svg"
+                    class="h-16 w-auto bg-gray-100 dark:bg-gray-900">
+                    <path
+                        d="M61.8548 14.6253C61.8778 14.7102 61.8895 14.7978 61.8897 14.8858V28.5615C61.8898 28.737 61.8434 28.9095 61.7554 29.0614C61.6675 29.2132 61.5409 29.3392 61.3887 29.4265L49.9104 36.0351V49.1337C49.9104 49.4902 49.7209 49.8192 49.4118 49.9987L25.4519 63.7916C25.3971 63.8227 25.3372 63.8427 25.2774 63.8639C25.255 63.8714 25.2338 63.8851 25.2101 63.8913C25.0426 63.9354 24.8666 63.9354 24.6991 63.8913C24.6716 63.8838 24.6467 63.8689 24.6205 63.8589C24.5657 63.8389 24.5084 63.8215 24.456 63.7916L0.501061 49.9987C0.348882 49.9113 0.222437 49.7853 0.134469 49.6334C0.0465019 49.4816 0.000120578 49.3092 0 49.1337L0 8.10652C0 8.01678 0.0124642 7.92953 0.0348998 7.84477C0.0423783 7.8161 0.0598282 7.78993 0.0697995 7.76126C0.0884958 7.70891 0.105946 7.65531 0.133367 7.6067C0.152063 7.5743 0.179485 7.54812 0.20192 7.51821C0.230588 7.47832 0.256763 7.43719 0.290416 7.40229C0.319084 7.37362 0.356476 7.35243 0.388883 7.32751C0.425029 7.29759 0.457436 7.26518 0.498568 7.2415L12.4779 0.345059C12.6296 0.257786 12.8015 0.211853 12.9765 0.211853C13.1515 0.211853 13.3234 0.257786 13.475 0.345059L25.4531 7.2415H25.4556C25.4955 7.26643 25.5292 7.29759 25.5653 7.32626C25.5977 7.35119 25.6339 7.37362 25.6625 7.40104C25.6974 7.43719 25.7224 7.47832 25.7523 7.51821C25.7735 7.54812 25.8021 7.5743 25.8196 7.6067C25.8483 7.65656 25.8645 7.70891 25.8844 7.76126C25.8944 7.78993 25.9118 7.8161 25.9193 7.84602C25.9423 7.93096 25.954 8.01853 25.9542 8.10652V33.7317L35.9355 27.9844V14.8846C35.9355 14.7973 35.948 14.7088 35.9704 14.6253C35.9792 14.5954 35.9954 14.5692 36.0053 14.5405C36.0253 14.4882 36.0427 14.4346 36.0702 14.386C36.0888 14.3536 36.1163 14.3274 36.1375 14.2975C36.1674 14.2576 36.1923 14.2165 36.2272 14.1816C36.2559 14.1529 36.292 14.1317 36.3244 14.1068C36.3618 14.0769 36.3942 14.0445 36.4341 14.0208L48.4147 7.12434C48.5663 7.03694 48.7383 6.99094 48.9133 6.99094C49.0883 6.99094 49.2602 7.03694 49.4118 7.12434L61.3899 14.0208C61.4323 14.0457 61.4647 14.0769 61.5021 14.1055C61.5333 14.1305 61.5694 14.1529 61.5981 14.1803C61.633 14.2165 61.6579 14.2576 61.6878 14.2975C61.7103 14.3274 61.7377 14.3536 61.7551 14.386C61.7838 14.4346 61.8 14.4882 61.8199 14.5405C61.8312 14.5692 61.8474 14.5954 61.8548 14.6253ZM59.893 27.9844V16.6121L55.7013 19.0252L49.9104 22.3593V33.7317L59.8942 27.9844H59.893ZM47.9149 48.5566V37.1768L42.2187 40.4299L25.953 49.7133V61.2003L47.9149 48.5566ZM1.99677 9.83281V48.5566L23.9562 61.199V49.7145L12.4841 43.2219L12.4804 43.2194L12.4754 43.2169C12.4368 43.1945 12.4044 43.1621 12.3682 43.1347C12.3371 43.1097 12.3009 43.0898 12.2735 43.0624L12.271 43.0586C12.2386 43.0275 12.2162 42.9888 12.1887 42.9539C12.1638 42.9203 12.1339 42.8916 12.114 42.8567L12.1127 42.853C12.0903 42.8156 12.0766 42.7707 12.0604 42.7283C12.0442 42.6909 12.023 42.656 12.013 42.6161C12.0005 42.5688 11.998 42.5177 11.9931 42.4691C11.9881 42.4317 11.9781 42.3943 11.9781 42.3569V15.5801L6.18848 12.2446L1.99677 9.83281ZM12.9777 2.36177L2.99764 8.10652L12.9752 13.8513L22.9541 8.10527L12.9752 2.36177H12.9777ZM18.1678 38.2138L23.9574 34.8809V9.83281L19.7657 12.2459L13.9749 15.5801V40.6281L18.1678 38.2138ZM48.9133 9.14105L38.9344 14.8858L48.9133 20.6305L58.8909 14.8846L48.9133 9.14105ZM47.9149 22.3593L42.124 19.0252L37.9323 16.6121V27.9844L43.7219 31.3174L47.9149 33.7317V22.3593ZM24.9533 47.987L39.59 39.631L46.9065 35.4555L36.9352 29.7145L25.4544 36.3242L14.9907 42.3482L24.9533 47.987Z"
+                        fill="#FF2D20" />
+                </svg>
+            </div>
+
+            <div class="mt-16">
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8">
+                    <a href="https://laravel.com/docs"
+                        class="scale-100 p-6 bg-white dark:bg-gray-800/50 dark:bg-gradient-to-bl from-gray-700/50 via-transparent dark:ring-1 dark:ring-inset dark:ring-white/5 rounded-lg shadow-2xl shadow-gray-500/20 dark:shadow-none flex motion-safe:hover:scale-[1.01] transition-all duration-250 focus:outline focus:outline-2 focus:outline-red-500">
+                        <div>
+                            <div
+                                class="h-16 w-16 bg-red-50 dark:bg-red-800/20 flex items-center justify-center rounded-full">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                                    stroke-width="1.5" class="w-7 h-7 stroke-red-500">
+                                    <path stroke-linecap="round" stroke-linejoin="round"
+                                        d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
                                 </svg>
-                                Sponsor
-                            </a>
-                        </div>
-                    </div>
+                            </div>
 
-                    <div class="ml-4 text-center text-sm text-gray-500 dark:text-gray-400 sm:text-right sm:ml-0">
-                        Laravel v{{ Illuminate\Foundation\Application::VERSION }} (PHP v{{ PHP_VERSION }})
+                            <h2 class="mt-6 text-xl font-semibold text-gray-900 dark:text-white">Documentation</h2>
+
+                            <p class="mt-4 text-gray-500 dark:text-gray-400 text-sm leading-relaxed">
+                                Laravel has wonderful documentation covering every aspect of the framework. Whether you
+                                are a newcomer or have prior experience with Laravel, we recommend reading our
+                                documentation from beginning to end.
+                            </p>
+                        </div>
+
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+                            class="self-center shrink-0 stroke-red-500 w-6 h-6 mx-6">
+                            <path stroke-linecap="round" stroke-linejoin="round"
+                                d="M4.5 12h15m0 0l-6.75-6.75M19.5 12l-6.75 6.75" />
+                        </svg>
+                    </a>
+
+                    <a href="https://laracasts.com"
+                        class="scale-100 p-6 bg-white dark:bg-gray-800/50 dark:bg-gradient-to-bl from-gray-700/50 via-transparent dark:ring-1 dark:ring-inset dark:ring-white/5 rounded-lg shadow-2xl shadow-gray-500/20 dark:shadow-none flex motion-safe:hover:scale-[1.01] transition-all duration-250 focus:outline focus:outline-2 focus:outline-red-500">
+                        <div>
+                            <div
+                                class="h-16 w-16 bg-red-50 dark:bg-red-800/20 flex items-center justify-center rounded-full">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                                    stroke-width="1.5" class="w-7 h-7 stroke-red-500">
+                                    <path stroke-linecap="round"
+                                        d="M15.75 10.5l4.72-4.72a.75.75 0 011.28.53v11.38a.75.75 0 01-1.28.53l-4.72-4.72M4.5 18.75h9a2.25 2.25 0 002.25-2.25v-9a2.25 2.25 0 00-2.25-2.25h-9A2.25 2.25 0 002.25 7.5v9a2.25 2.25 0 002.25 2.25z" />
+                                </svg>
+                            </div>
+
+                            <h2 class="mt-6 text-xl font-semibold text-gray-900 dark:text-white">Laracasts</h2>
+
+                            <p class="mt-4 text-gray-500 dark:text-gray-400 text-sm leading-relaxed">
+                                Laracasts offers thousands of video tutorials on Laravel, PHP, and JavaScript
+                                development. Check them out, see for yourself, and massively level up your development
+                                skills in the process.
+                            </p>
+                        </div>
+
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+                            class="self-center shrink-0 stroke-red-500 w-6 h-6 mx-6">
+                            <path stroke-linecap="round" stroke-linejoin="round"
+                                d="M4.5 12h15m0 0l-6.75-6.75M19.5 12l-6.75 6.75" />
+                        </svg>
+                    </a>
+
+                    <a href="https://laravel-news.com"
+                        class="scale-100 p-6 bg-white dark:bg-gray-800/50 dark:bg-gradient-to-bl from-gray-700/50 via-transparent dark:ring-1 dark:ring-inset dark:ring-white/5 rounded-lg shadow-2xl shadow-gray-500/20 dark:shadow-none flex motion-safe:hover:scale-[1.01] transition-all duration-250 focus:outline focus:outline-2 focus:outline-red-500">
+                        <div>
+                            <div
+                                class="h-16 w-16 bg-red-50 dark:bg-red-800/20 flex items-center justify-center rounded-full">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                                    stroke-width="1.5" class="w-7 h-7 stroke-red-500">
+                                    <path stroke-linecap="round" stroke-linejoin="round"
+                                        d="M12 7.5h1.5m-1.5 3h1.5m-7.5 3h7.5m-7.5 3h7.5m3-9h3.375c.621 0 1.125.504 1.125 1.125V18a2.25 2.25 0 01-2.25 2.25M16.5 7.5V18a2.25 2.25 0 002.25 2.25M16.5 7.5V4.875c0-.621-.504-1.125-1.125-1.125H4.125C3.504 3.75 3 4.254 3 4.875V18a2.25 2.25 0 002.25 2.25h13.5M6 7.5h3v3H6v-3z" />
+                                </svg>
+                            </div>
+
+                            <h2 class="mt-6 text-xl font-semibold text-gray-900 dark:text-white">Laravel News</h2>
+
+                            <p class="mt-4 text-gray-500 dark:text-gray-400 text-sm leading-relaxed">
+                                Laravel News is a community driven portal and newsletter aggregating all of the latest
+                                and most important news in the Laravel ecosystem, including new package releases and
+                                tutorials.
+                            </p>
+                        </div>
+
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+                            class="self-center shrink-0 stroke-red-500 w-6 h-6 mx-6">
+                            <path stroke-linecap="round" stroke-linejoin="round"
+                                d="M4.5 12h15m0 0l-6.75-6.75M19.5 12l-6.75 6.75" />
+                        </svg>
+                    </a>
+
+                    <div
+                        class="scale-100 p-6 bg-white dark:bg-gray-800/50 dark:bg-gradient-to-bl from-gray-700/50 via-transparent dark:ring-1 dark:ring-inset dark:ring-white/5 rounded-lg shadow-2xl shadow-gray-500/20 dark:shadow-none flex motion-safe:hover:scale-[1.01] transition-all duration-250 focus:outline focus:outline-2 focus:outline-red-500">
+                        <div>
+                            <div
+                                class="h-16 w-16 bg-red-50 dark:bg-red-800/20 flex items-center justify-center rounded-full">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                                    stroke-width="1.5" class="w-7 h-7 stroke-red-500">
+                                    <path stroke-linecap="round" stroke-linejoin="round"
+                                        d="M6.115 5.19l.319 1.913A6 6 0 008.11 10.36L9.75 12l-.387.775c-.217.433-.132.956.21 1.298l1.348 1.348c.21.21.329.497.329.795v1.089c0 .426.24.815.622 1.006l.153.076c.433.217.956.132 1.298-.21l.723-.723a8.7 8.7 0 002.288-4.042 1.087 1.087 0 00-.358-1.099l-1.33-1.108c-.251-.21-.582-.299-.905-.245l-1.17.195a1.125 1.125 0 01-.98-.314l-.295-.295a1.125 1.125 0 010-1.591l.13-.132a1.125 1.125 0 011.3-.21l.603.302a.809.809 0 001.086-1.086L14.25 7.5l1.256-.837a4.5 4.5 0 001.528-1.732l.146-.292M6.115 5.19A9 9 0 1017.18 4.64M6.115 5.19A8.965 8.965 0 0112 3c1.929 0 3.716.607 5.18 1.64" />
+                                </svg>
+                            </div>
+
+                            <h2 class="mt-6 text-xl font-semibold text-gray-900 dark:text-white">Vibrant Ecosystem</h2>
+
+                            <p class="mt-4 text-gray-500 dark:text-gray-400 text-sm leading-relaxed">
+                                Laravel's robust library of first-party tools and libraries, such as <a
+                                    href="https://forge.laravel.com"
+                                    class="underline hover:text-gray-700 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Forge</a>,
+                                <a href="https://vapor.laravel.com"
+                                    class="underline hover:text-gray-700 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Vapor</a>,
+                                <a href="https://nova.laravel.com"
+                                    class="underline hover:text-gray-700 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Nova</a>,
+                                and <a href="https://envoyer.io"
+                                    class="underline hover:text-gray-700 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Envoyer</a>
+                                help you take your projects to the next level. Pair them with powerful open source
+                                libraries like <a href="https://laravel.com/docs/billing"
+                                    class="underline hover:text-gray-700 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Cashier</a>,
+                                <a href="https://laravel.com/docs/dusk"
+                                    class="underline hover:text-gray-700 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Dusk</a>,
+                                <a href="https://laravel.com/docs/broadcasting"
+                                    class="underline hover:text-gray-700 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Echo</a>,
+                                <a href="https://laravel.com/docs/horizon"
+                                    class="underline hover:text-gray-700 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Horizon</a>,
+                                <a href="https://laravel.com/docs/sanctum"
+                                    class="underline hover:text-gray-700 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Sanctum</a>,
+                                <a href="https://laravel.com/docs/telescope"
+                                    class="underline hover:text-gray-700 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Telescope</a>,
+                                and more.
+                            </p>
+                        </div>
                     </div>
                 </div>
             </div>
+
+            <div class="flex justify-center mt-16 px-0 sm:items-center sm:justify-between">
+                <div class="text-center text-sm text-gray-500 dark:text-gray-400 sm:text-left">
+                    <div class="flex items-center gap-4">
+                        <a href="https://github.com/sponsors/taylorotwell"
+                            class="group inline-flex items-center hover:text-gray-700 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                                stroke-width="1.5"
+                                class="-mt-px mr-1 w-5 h-5 stroke-gray-400 dark:stroke-gray-600 group-hover:stroke-gray-600 dark:group-hover:stroke-gray-400">
+                                <path stroke-linecap="round" stroke-linejoin="round"
+                                    d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z" />
+                            </svg>
+                            Sponsor
+                        </a>
+                    </div>
+                </div>
+
+                <div class="ml-4 text-center text-sm text-gray-500 dark:text-gray-400 sm:text-right sm:ml-0">
+                    Laravel v{{ Illuminate\Foundation\Application::VERSION }} (PHP v{{ PHP_VERSION }})
+                </div>
+            </div>
         </div>
-    </body>
+    </div>
+</body>
+
 </html>


### PR DESCRIPTION
## Summary

Modernize the UI to Bootstrap 5 conventions. No business logic or database write behavior is changed.

## Context / Why

Some views still used BS4-ish patterns and custom classes. Aligning to Bootstrap 5 improves consistency, maintainability, and reduces custom CSS.

## Changes

### Bootstrap 5 UI polish
- Replace deprecated/legacy classes:
  - `float-right` → `ms-auto`, `mr-*`/`ml-*` → `me-*`/`ms-*`
  - `form-group`/custom wrappers → `mb-3` with `form-label` + `form-control`
  - `<select>` → `form-select`
  - Remove non-core classes (`page-header`, `page-title`) in favor of BS5 utilities
- Tables:
  - Wrap in `.table-responsive` + `align-middle`, use `<th>` for label cells
- Layout:
  - Avoid nested `.container` between layout & child views
- Minor UX:
  - Consistent card spacing `shadow-sm`, button groups, and `gap-*` utilities
- Pagination:
  - Ensure `Paginator::useBootstrapFive()` enabled (see Notes)

## What’s NOT included

* No database schema changes
* No create/update logic changes
* No queue/scheduler changes
